### PR TITLE
Fix small version typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ You will need [Cargo and Rust](https://www.rust-lang.org/en-US/downloads.html).
 Add the following to `Cargo.toml`:
 
 ```toml
-pest = "1.0-beta.1"
-pest_derive = "1.0-beta.1"
+pest = "1.0.0-beta.1"
+pest_derive = "1.0.0-beta.1"
 ```
 
 and in your Rust `lib.rs` or `main.rs`:


### PR DESCRIPTION
The crates.io versions in the text of the readme is missing the patch component, causing a parsing error (well, not really, just cargo can't find it).