### PR TITLE
Allow StringInput from borrowed str, to avoid copy

### DIFF
--- a/pest/src/inputs/file_input.rs
+++ b/pest/src/inputs/file_input.rs
@@ -18,7 +18,7 @@ use super::{Input, StringInput};
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FileInput {
     input: StringInput,
-    file_name: OsString,
+    file_name: OsString
 }
 
 impl FileInput {

--- a/pest/src/inputs/file_input.rs
+++ b/pest/src/inputs/file_input.rs
@@ -16,12 +16,12 @@ use super::{Input, StringInput};
 
 /// A `struct` useful for matching `File`s by allocating the contents at the beginning.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct FileInput<'a> {
-    input: StringInput<'a>,
-    file_name: OsString
+pub struct FileInput {
+    input: StringInput,
+    file_name: OsString,
 }
 
-impl<'a> FileInput<'a> {
+impl FileInput {
     /// Creates a new `FileInput` from a `File`.
     ///
     /// # Examples
@@ -30,7 +30,7 @@ impl<'a> FileInput<'a> {
     /// # use pest::inputs::FileInput;
     /// FileInput::new("file").unwrap();
     /// ```
-    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<FileInput<'a>> {
+    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<FileInput> {
         let mut file = File::open(path.as_ref())?;
         let mut string = String::new();
         file.read_to_string(&mut string)?;
@@ -38,16 +38,11 @@ impl<'a> FileInput<'a> {
         let input = StringInput::new(string);
         let file_name = path.as_ref().file_name().unwrap().to_os_string();
 
-        Ok(
-            FileInput {
-                input,
-                file_name
-            }
-        )
+        Ok(FileInput { input, file_name })
     }
 }
 
-impl<'a> Input for FileInput<'a> {
+impl Input for FileInput {
     #[inline]
     fn len(&self) -> usize {
         self.input.len()

--- a/pest/src/inputs/file_input.rs
+++ b/pest/src/inputs/file_input.rs
@@ -16,12 +16,12 @@ use super::{Input, StringInput};
 
 /// A `struct` useful for matching `File`s by allocating the contents at the beginning.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct FileInput {
-    input: StringInput,
+pub struct FileInput<'a> {
+    input: StringInput<'a>,
     file_name: OsString
 }
 
-impl FileInput {
+impl<'a> FileInput<'a> {
     /// Creates a new `FileInput` from a `File`.
     ///
     /// # Examples
@@ -30,7 +30,7 @@ impl FileInput {
     /// # use pest::inputs::FileInput;
     /// FileInput::new("file").unwrap();
     /// ```
-    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<FileInput> {
+    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<FileInput<'a>> {
         let mut file = File::open(path.as_ref())?;
         let mut string = String::new();
         file.read_to_string(&mut string)?;
@@ -47,7 +47,7 @@ impl FileInput {
     }
 }
 
-impl Input for FileInput {
+impl<'a> Input for FileInput<'a> {
     #[inline]
     fn len(&self) -> usize {
         self.input.len()

--- a/pest/src/inputs/mod.rs
+++ b/pest/src/inputs/mod.rs
@@ -16,5 +16,5 @@ mod string_input;
 pub use self::file_input::FileInput;
 pub use self::input::Input;
 pub use self::position::Position;
-pub use self::string_input::StringInput;
+pub use self::string_input::{StringInput, StrInput};
 pub use self::span::Span;

--- a/pest/src/inputs/span.rs
+++ b/pest/src/inputs/span.rs
@@ -19,19 +19,15 @@ use super::position;
 pub struct Span<I: Input> {
     input: Rc<I>,
     start: usize,
-    end: usize
+    end: usize,
 }
 
 #[inline]
 pub fn new<I: Input>(input: Rc<I>, start: usize, end: usize) -> Span<I> {
-    Span {
-        input,
-        start,
-        end
-    }
+    Span { input, start, end }
 }
 
-impl<I: Input> Span<I> {
+impl<'a, I: Input> Span<I> {
     /// Returns the `Span`'s start position as a `usize`.
     ///
     /// # Examples
@@ -148,7 +144,7 @@ impl<I: Input> Span<I> {
     /// assert_eq!(span.as_str(), "b");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&'a self) -> &'a str {
         unsafe { self.input.slice(self.start, self.end) }
     }
 }
@@ -169,9 +165,7 @@ impl<I: Input> Clone for Span<I> {
 
 impl<I: Input> PartialEq for Span<I> {
     fn eq(&self, other: &Span<I>) -> bool {
-        Rc::ptr_eq(&self.input, &other.input) &&
-        self.start == other.start &&
-        self.end == other.end
+        Rc::ptr_eq(&self.input, &other.input) && self.start == other.start && self.end == other.end
     }
 }
 
@@ -182,7 +176,7 @@ impl<I: Input> PartialOrd for Span<I> {
         if Rc::ptr_eq(&self.input, &other.input) {
             match self.start.partial_cmp(&other.start) {
                 Some(Ordering::Equal) => self.end.partial_cmp(&other.end),
-                ordering => ordering
+                ordering => ordering,
             }
         } else {
             None
@@ -192,7 +186,9 @@ impl<I: Input> PartialOrd for Span<I> {
 
 impl<I: Input> Ord for Span<I> {
     fn cmp(&self, other: &Span<I>) -> Ordering {
-        self.partial_cmp(other).expect("cannot compare spans from different inputs")
+        self.partial_cmp(other).expect(
+            "cannot compare spans from different inputs",
+        )
     }
 }
 

--- a/pest/src/inputs/span.rs
+++ b/pest/src/inputs/span.rs
@@ -176,7 +176,7 @@ impl<I: Input> PartialOrd for Span<I> {
         if Rc::ptr_eq(&self.input, &other.input) {
             match self.start.partial_cmp(&other.start) {
                 Some(Ordering::Equal) => self.end.partial_cmp(&other.end),
-                ordering => ordering,
+                ordering => ordering
             }
         } else {
             None

--- a/pest/src/inputs/span.rs
+++ b/pest/src/inputs/span.rs
@@ -144,7 +144,7 @@ impl<'a, I: Input> Span<I> {
     /// assert_eq!(span.as_str(), "b");
     /// ```
     #[inline]
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &str {
         unsafe { self.input.slice(self.start, self.end) }
     }
 }

--- a/pest/src/inputs/span.rs
+++ b/pest/src/inputs/span.rs
@@ -19,7 +19,7 @@ use super::position;
 pub struct Span<I: Input> {
     input: Rc<I>,
     start: usize,
-    end: usize,
+    end: usize
 }
 
 #[inline]
@@ -27,7 +27,7 @@ pub fn new<I: Input>(input: Rc<I>, start: usize, end: usize) -> Span<I> {
     Span { input, start, end }
 }
 
-impl<'a, I: Input> Span<I> {
+impl<I: Input> Span<I> {
     /// Returns the `Span`'s start position as a `usize`.
     ///
     /// # Examples
@@ -187,12 +187,13 @@ impl<I: Input> PartialOrd for Span<I> {
 impl<I: Input> Ord for Span<I> {
     fn cmp(&self, other: &Span<I>) -> Ordering {
         self.partial_cmp(other).expect(
-            "cannot compare spans from different inputs",
+            "cannot compare spans from \
+             different inputs"
         )
     }
 }
 
-impl<'a, I: Input> Hash for Span<I> {
+impl<I: Input> Hash for Span<I> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (&*self.input as *const I).hash(state);
         self.start.hash(state);

--- a/pest/src/inputs/string_input.rs
+++ b/pest/src/inputs/string_input.rs
@@ -15,13 +15,13 @@ use super::Input;
 /// A `struct` useful for matching heap-allocated `String`s.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct StringInput {
-    string: String,
+    string: String
 }
 
 /// A `struct` useful for matching borrowed `str`s.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct StrInput<'a> {
-    str_ref: &'a str,
+    str_ref: &'a str
 }
 
 impl StringInput {
@@ -114,11 +114,10 @@ unsafe fn line_of(source: &str, mut pos: usize) -> &str {
             pos -= 1;
         }
 
-        let start = source
-            .char_indices()
-            .rev()
-            .skip_while(|&(i, _)| i > pos)
-            .find(|&(_, c)| c == '\n');
+        let start = source.char_indices()
+                          .rev()
+                          .skip_while(|&(i, _)| i > pos)
+                          .find(|&(_, c)| c == '\n');
         match start {
             Some((i, _)) => i + 1,
             None => 0,
@@ -143,7 +142,7 @@ unsafe fn line_of(source: &str, mut pos: usize) -> &str {
             |&(_,
                c)| {
                 c == '\n'
-            },
+            }
         );
         let mut end = match end {
             Some((i, _)) => i,

--- a/pest/src/inputs/string_input.rs
+++ b/pest/src/inputs/string_input.rs
@@ -328,6 +328,14 @@ mod tests {
             assert!(input.match_string("", 0));
             assert!(!input.match_string("a", 0));
         }
+
+        let input2 = StrInput::new("");
+
+        unsafe {
+            assert!(input2.is_empty());
+            assert!(input2.match_string("", 0));
+            assert!(!input2.match_string("a", 0));
+        }
     }
 
     #[test]
@@ -339,11 +347,20 @@ mod tests {
             assert!(input.match_string("asd", 0));
             assert!(input.match_string("asdf", 3));
         }
+
+        let input2 = StrInput::new("asdasdf");
+
+        unsafe {
+            assert!(!input2.is_empty());
+            assert!(input2.match_string("asd", 0));
+            assert!(input2.match_string("asdf", 3));
+        }
     }
 
     #[test]
     fn len() {
         assert_eq!(StringInput::new("asdasdf".to_owned()).len(), 7);
+        assert_eq!(StrInput::new("asdasdf").len(), 7);
     }
 
     #[test]
@@ -352,6 +369,12 @@ mod tests {
 
         unsafe {
             assert_eq!(input.slice(1, 3), "sd");
+        }
+
+        let input2 = StrInput::new("asdasdf");
+
+        unsafe {
+            assert_eq!(input2.slice(1, 3), "sd");
         }
     }
 
@@ -371,6 +394,21 @@ mod tests {
             assert_eq!(input.line_col(8), (3, 2));
             assert_eq!(input.line_col(11), (3, 3));
         }
+
+        let input2 = StrInput::new("a\rb\nc\r\nd嗨");
+
+        unsafe {
+            assert_eq!(input2.line_col(0), (1, 1));
+            assert_eq!(input2.line_col(1), (1, 2));
+            assert_eq!(input2.line_col(2), (1, 3));
+            assert_eq!(input2.line_col(3), (1, 4));
+            assert_eq!(input2.line_col(4), (2, 1));
+            assert_eq!(input2.line_col(5), (2, 2));
+            assert_eq!(input2.line_col(6), (2, 3));
+            assert_eq!(input2.line_col(7), (3, 1));
+            assert_eq!(input2.line_col(8), (3, 2));
+            assert_eq!(input2.line_col(11), (3, 3));
+        }
     }
 
     #[test]
@@ -389,6 +427,21 @@ mod tests {
             assert_eq!(input.line_of(8), "d嗨");
             assert_eq!(input.line_of(11), "d嗨");
         }
+
+        let input2 = StrInput::new("a\rb\nc\r\nd嗨");
+
+        unsafe {
+            assert_eq!(input2.line_of(0), "a\rb");
+            assert_eq!(input2.line_of(1), "a\rb");
+            assert_eq!(input2.line_of(2), "a\rb");
+            assert_eq!(input2.line_of(3), "a\rb");
+            assert_eq!(input2.line_of(4), "c");
+            assert_eq!(input2.line_of(5), "c");
+            assert_eq!(input2.line_of(6), "c");
+            assert_eq!(input2.line_of(7), "d嗨");
+            assert_eq!(input2.line_of(8), "d嗨");
+            assert_eq!(input2.line_of(11), "d嗨");
+        }
     }
 
     #[test]
@@ -398,6 +451,12 @@ mod tests {
         unsafe {
             assert_eq!(input.line_of(0), "");
         }
+
+        let input2 = StrInput::new("");
+
+        unsafe {
+            assert_eq!(input2.line_of(0), "");
+        }
     }
 
     #[test]
@@ -406,6 +465,12 @@ mod tests {
 
         unsafe {
             assert_eq!(input.line_of(0), "");
+        }
+
+        let input2 = StrInput::new("\n");
+
+        unsafe {
+            assert_eq!(input2.line_of(0), "");
         }
     }
 
@@ -417,6 +482,13 @@ mod tests {
             assert_eq!(input.skip(0, 0), Some(0));
             assert_eq!(input.skip(1, 0), None);
         }
+
+        let input2 = StrInput::new("");
+
+        unsafe {
+            assert_eq!(input2.skip(0, 0), Some(0));
+            assert_eq!(input2.skip(1, 0), None);
+        }
     }
 
     #[test]
@@ -427,6 +499,14 @@ mod tests {
             assert_eq!(input.skip(0, 0), Some(0));
             assert_eq!(input.skip(1, 0), Some(1));
             assert_eq!(input.skip(1, 1), Some(3));
+        }
+
+        let input2 = StrInput::new("d嗨");
+
+        unsafe {
+            assert_eq!(input2.skip(0, 0), Some(0));
+            assert_eq!(input2.skip(1, 0), Some(1));
+            assert_eq!(input2.skip(1, 1), Some(3));
         }
     }
 
@@ -441,6 +521,16 @@ mod tests {
             assert!(input.match_range('c'..'c', 0).is_none());
             assert!(input.match_range('a'..'嗨', 0).is_some());
         }
+
+        let input2 = StrInput::new("b");
+
+        unsafe {
+            assert!(input2.match_range('a'..'c', 0).is_some());
+            assert!(input2.match_range('b'..'b', 0).is_some());
+            assert!(input2.match_range('a'..'a', 0).is_none());
+            assert!(input2.match_range('c'..'c', 0).is_none());
+            assert!(input2.match_range('a'..'嗨', 0).is_some());
+        }
     }
 
     #[test]
@@ -450,6 +540,13 @@ mod tests {
         unsafe {
             assert!(input.match_insensitive("asd", 0));
             assert!(input.match_insensitive("asdf", 3));
+        }
+
+        let input2 = StrInput::new("AsdASdF");
+
+        unsafe {
+            assert!(input2.match_insensitive("asd", 0));
+            assert!(input2.match_insensitive("asdf", 3));
         }
     }
 }

--- a/pest/src/inputs/string_input.rs
+++ b/pest/src/inputs/string_input.rs
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::borrow::Cow;
 use std::ascii::AsciiExt;
 use std::ffi::OsString;
 use std::ops::Range;
@@ -15,11 +14,17 @@ use super::Input;
 
 /// A `struct` useful for matching heap-allocated `String`s.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct StringInput<'a> {
-    string: Cow<'a, str>,
+pub struct StringInput {
+    string: String,
 }
 
-impl<'a> StringInput<'a> {
+/// A `struct` useful for matching borrowed `str`s.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct StrInput<'a> {
+    str_ref: &'a str,
+}
+
+impl StringInput {
     /// Creates a new `StringInput` from a `String`.
     ///
     /// # Examples
@@ -30,26 +35,187 @@ impl<'a> StringInput<'a> {
     ///
     /// assert_eq!(input.len(), 3);
     /// ```
-    pub fn new(string: String) -> StringInput<'a> {
-        StringInput { string: Cow::Owned(string) }
+    pub fn new(string: String) -> StringInput {
+        StringInput { string }
     }
+}
 
-    /// Creates a new `StringInput` from a `&str`.
+impl<'a> StrInput<'a> {
+    /// Creates a new `StrInput` from a `&str`.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use pest::inputs::{Input, StringInput};
-    /// let input = StringInput::new_borrowed("asd");
+    /// # use pest::inputs::{Input, StrInput};
+    /// let input = StrInput::new("asd");
     ///
     /// assert_eq!(input.len(), 3);
     /// ```
-    pub fn new_borrowed(source: &'a str) -> StringInput<'a> {
-        StringInput { string: Cow::Borrowed(source) }
+    pub fn new(source: &'a str) -> StrInput<'a> {
+        StrInput { str_ref: source }
     }
 }
 
-impl<'a> Input for StringInput<'a> {
+#[inline]
+unsafe fn line_col(source: &str, pos: usize) -> (usize, usize) {
+    if pos > source.len() {
+        panic!("position out of bounds");
+    }
+
+    let mut pos = pos;
+    let slice = &source[..pos];
+    let mut chars = slice.chars().peekable();
+
+    let mut line_col = (1, 1);
+
+    while pos != 0 {
+        match chars.next() {
+            Some('\r') => {
+                if let Some(&'\n') = chars.peek() {
+                    chars.next();
+
+                    if pos == 1 {
+                        pos -= 1;
+                    } else {
+                        pos -= 2;
+                    }
+
+                    line_col = (line_col.0 + 1, 1);
+                } else {
+                    pos -= 1;
+                    line_col = (line_col.0, line_col.1 + 1);
+                }
+            }
+            Some('\n') => {
+                pos -= 1;
+                line_col = (line_col.0 + 1, 1);
+            }
+            Some(c) => {
+                pos -= c.len_utf8();
+                line_col = (line_col.0, line_col.1 + 1);
+            }
+            None => unreachable!(),
+        }
+    }
+
+    line_col
+}
+
+#[inline]
+unsafe fn line_of(source: &str, mut pos: usize) -> &str {
+    if pos > source.len() {
+        panic!("position out of bounds");
+    }
+
+    let start = if pos == 0 {
+        0
+    } else {
+        if source.slice_unchecked(pos, pos + 1) == "\n" {
+            pos -= 1;
+        }
+
+        let start = source
+            .char_indices()
+            .rev()
+            .skip_while(|&(i, _)| i > pos)
+            .find(|&(_, c)| c == '\n');
+        match start {
+            Some((i, _)) => i + 1,
+            None => 0,
+        }
+    };
+
+    let end = if source.len() == 0 {
+        0
+    } else if pos == source.len() - 1 {
+        let mut end = source.len();
+
+        if end > 0 && source.slice_unchecked(end - 1, end) == "\n" {
+            end -= 1;
+        }
+        if end > 0 && source.slice_unchecked(end - 1, end) == "\r" {
+            end -= 1;
+        }
+
+        end
+    } else {
+        let end = source.char_indices().skip_while(|&(i, _)| i < pos).find(
+            |&(_,
+               c)| {
+                c == '\n'
+            },
+        );
+        let mut end = match end {
+            Some((i, _)) => i,
+            None => source.len(),
+        };
+
+        if end > 0 && source.slice_unchecked(end - 1, end) == "\r" {
+            end -= 1;
+        }
+
+        end
+    };
+
+    source.slice_unchecked(start, end)
+}
+
+#[inline]
+unsafe fn skip(source: &str, n: usize, pos: usize) -> Option<usize> {
+    let mut len = 0;
+    let mut chars = source.slice_unchecked(pos, source.len()).chars();
+
+    for _ in 0..n {
+        if let Some(c) = chars.next() {
+            len += c.len_utf8();
+        } else {
+            return None;
+        }
+    }
+
+    Some(len)
+}
+
+#[inline]
+unsafe fn match_string(source: &str, string: &str, pos: usize) -> bool {
+    let to = pos + string.len();
+
+    if to <= source.len() {
+        let slice = source.slice_unchecked(pos, to);
+        slice == string
+    } else {
+        false
+    }
+}
+
+#[inline]
+unsafe fn match_insensitive(source: &str, string: &str, pos: usize) -> bool {
+    let slice = source.slice_unchecked(pos, source.len());
+
+    if slice.is_char_boundary(string.len()) {
+        let slice = slice.slice_unchecked(0, string.len());
+        slice.eq_ignore_ascii_case(string)
+    } else {
+        false
+    }
+}
+
+#[inline]
+unsafe fn match_range(source: &str, range: Range<char>, pos: usize) -> Option<usize> {
+    let slice = source.slice_unchecked(pos, source.len());
+
+    if let Some(char) = slice.chars().next() {
+        if range.start <= char && char <= range.end {
+            Some(char.len_utf8())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+impl Input for StringInput {
     #[inline]
     fn len(&self) -> usize {
         self.string.len()
@@ -71,158 +237,81 @@ impl<'a> Input for StringInput<'a> {
     }
 
     unsafe fn line_col(&self, pos: usize) -> (usize, usize) {
-        if pos > self.string.len() {
-            panic!("position out of bounds");
-        }
-
-        let mut pos = pos;
-        let slice = &self.string[..pos];
-        let mut chars = slice.chars().peekable();
-
-        let mut line_col = (1, 1);
-
-        while pos != 0 {
-            match chars.next() {
-                Some('\r') => {
-                    if let Some(&'\n') = chars.peek() {
-                        chars.next();
-
-                        if pos == 1 {
-                            pos -= 1;
-                        } else {
-                            pos -= 2;
-                        }
-
-                        line_col = (line_col.0 + 1, 1);
-                    } else {
-                        pos -= 1;
-                        line_col = (line_col.0, line_col.1 + 1);
-                    }
-                }
-                Some('\n') => {
-                    pos -= 1;
-                    line_col = (line_col.0 + 1, 1);
-                }
-                Some(c) => {
-                    pos -= c.len_utf8();
-                    line_col = (line_col.0, line_col.1 + 1);
-                }
-                None => unreachable!(),
-            }
-        }
-
-        line_col
+        line_col(&self.string, pos)
     }
 
-    unsafe fn line_of(&self, mut pos: usize) -> &str {
-        if pos > self.string.len() {
-            panic!("position out of bounds");
-        }
-
-        let start = if pos == 0 {
-            0
-        } else {
-            if self.string.slice_unchecked(pos, pos + 1) == "\n" {
-                pos -= 1;
-            }
-
-            let start = self.string
-                .char_indices()
-                .rev()
-                .skip_while(|&(i, _)| i > pos)
-                .find(|&(_, c)| c == '\n');
-            match start {
-                Some((i, _)) => i + 1,
-                None => 0,
-            }
-        };
-
-        let end = if self.string.len() == 0 {
-            0
-        } else if pos == self.string.len() - 1 {
-            let mut end = self.string.len();
-
-            if end > 0 && self.string.slice_unchecked(end - 1, end) == "\n" {
-                end -= 1;
-            }
-            if end > 0 && self.string.slice_unchecked(end - 1, end) == "\r" {
-                end -= 1;
-            }
-
-            end
-        } else {
-            let end = self.string
-                .char_indices()
-                .skip_while(|&(i, _)| i < pos)
-                .find(|&(_, c)| c == '\n');
-            let mut end = match end {
-                Some((i, _)) => i,
-                None => self.string.len(),
-            };
-
-            if end > 0 && self.string.slice_unchecked(end - 1, end) == "\r" {
-                end -= 1;
-            }
-
-            end
-        };
-
-        self.string.slice_unchecked(start, end)
+    unsafe fn line_of(&self, pos: usize) -> &str {
+        line_of(&self.string, pos)
     }
 
     #[inline]
     unsafe fn skip(&self, n: usize, pos: usize) -> Option<usize> {
-        let mut len = 0;
-        let mut chars = self.string.slice_unchecked(pos, self.string.len()).chars();
-
-        for _ in 0..n {
-            if let Some(c) = chars.next() {
-                len += c.len_utf8();
-            } else {
-                return None;
-            }
-        }
-
-        Some(len)
+        skip(&self.string, n, pos)
     }
 
     #[inline]
     unsafe fn match_string(&self, string: &str, pos: usize) -> bool {
-        let to = pos + string.len();
-
-        if to <= self.string.len() {
-            let slice = self.string.slice_unchecked(pos, to);
-            slice == string
-        } else {
-            false
-        }
+        match_string(&self.string, string, pos)
     }
 
     #[inline]
     unsafe fn match_insensitive(&self, string: &str, pos: usize) -> bool {
-        let slice = self.string.slice_unchecked(pos, self.string.len());
-
-        if slice.is_char_boundary(string.len()) {
-            let slice = slice.slice_unchecked(0, string.len());
-            slice.eq_ignore_ascii_case(string)
-        } else {
-            false
-        }
+        match_insensitive(&self.string, string, pos)
     }
 
     #[inline]
     unsafe fn match_range(&self, range: Range<char>, pos: usize) -> Option<usize> {
-        let slice = self.string.slice_unchecked(pos, self.string.len());
+        match_range(&self.string, range, pos)
+    }
+}
 
-        if let Some(char) = slice.chars().next() {
-            if range.start <= char && char <= range.end {
-                Some(char.len_utf8())
-            } else {
-                None
-            }
-        } else {
-            None
-        }
+impl<'a> Input for StrInput<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.str_ref.len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.str_ref.is_empty()
+    }
+
+    #[inline]
+    fn file_name(&self) -> Option<OsString> {
+        None
+    }
+
+    #[inline]
+    unsafe fn slice(&self, start: usize, end: usize) -> &str {
+        self.str_ref.slice_unchecked(start, end)
+    }
+
+    unsafe fn line_col(&self, pos: usize) -> (usize, usize) {
+        line_col(self.str_ref, pos)
+    }
+
+    unsafe fn line_of(&self, pos: usize) -> &str {
+        line_of(self.str_ref, pos)
+    }
+
+    #[inline]
+    unsafe fn skip(&self, n: usize, pos: usize) -> Option<usize> {
+        skip(self.str_ref, n, pos)
+    }
+
+    #[inline]
+    unsafe fn match_string(&self, string: &str, pos: usize) -> bool {
+        match_string(self.str_ref, string, pos)
+    }
+
+    #[inline]
+    unsafe fn match_insensitive(&self, string: &str, pos: usize) -> bool {
+        match_insensitive(self.str_ref, string, pos)
+    }
+
+    #[inline]
+    unsafe fn match_range(&self, range: Range<char>, pos: usize) -> Option<usize> {
+        match_range(self.str_ref, range, pos)
     }
 }
 

--- a/pest/src/inputs/string_input.rs
+++ b/pest/src/inputs/string_input.rs
@@ -94,7 +94,7 @@ unsafe fn line_col(source: &str, pos: usize) -> (usize, usize) {
                 pos -= c.len_utf8();
                 line_col = (line_col.0, line_col.1 + 1);
             }
-            None => unreachable!(),
+            None => unreachable!()
         }
     }
 
@@ -120,7 +120,7 @@ unsafe fn line_of(source: &str, mut pos: usize) -> &str {
                           .find(|&(_, c)| c == '\n');
         match start {
             Some((i, _)) => i + 1,
-            None => 0,
+            None => 0
         }
     };
 
@@ -138,15 +138,12 @@ unsafe fn line_of(source: &str, mut pos: usize) -> &str {
 
         end
     } else {
-        let end = source.char_indices().skip_while(|&(i, _)| i < pos).find(
-            |&(_,
-               c)| {
-                c == '\n'
-            }
-        );
+        let end = source.char_indices()
+                        .skip_while(|&(i, _)| i < pos)
+                        .find(|&(_, c)| c == '\n');
         let mut end = match end {
             Some((i, _)) => i,
-            None => source.len(),
+            None => source.len()
         };
 
         if end > 0 && source.slice_unchecked(end - 1, end) == "\r" {

--- a/pest/src/parser.rs
+++ b/pest/src/parser.rs
@@ -18,6 +18,6 @@ pub trait Parser<R: RuleType> {
     fn parse<I: Input>(rule: R, input: Rc<I>) -> Result<Pairs<R, I>, Error<R, I>>;
     /// Parses an `input` &str starting from `rule`.
     fn parse_str(rule: R, input: &str) -> Result<Pairs<R, StringInput>, Error<R, StringInput>> {
-        Self::parse(rule, Rc::new(StringInput::new(input.to_owned())))
+        Self::parse(rule, Rc::new(StringInput::new_borrowed(input)))
     }
 }

--- a/pest/src/parser.rs
+++ b/pest/src/parser.rs
@@ -8,7 +8,7 @@
 use std::rc::Rc;
 
 use super::error::Error;
-use super::inputs::{Input, StringInput};
+use super::inputs::{Input, StrInput};
 use super::iterators::Pairs;
 use super::RuleType;
 
@@ -17,7 +17,7 @@ pub trait Parser<R: RuleType> {
     /// Parses `input` starting from `rule`.
     fn parse<I: Input>(rule: R, input: Rc<I>) -> Result<Pairs<R, I>, Error<R, I>>;
     /// Parses an `input` &str starting from `rule`.
-    fn parse_str(rule: R, input: &str) -> Result<Pairs<R, StringInput>, Error<R, StringInput>> {
-        Self::parse(rule, Rc::new(StringInput::new_borrowed(input)))
+    fn parse_str(rule: R, input: &str) -> Result<Pairs<R, StrInput>, Error<R, StrInput>> {
+        Self::parse(rule, Rc::new(StrInput::new(input)))
     }
 }

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -10,7 +10,7 @@ extern crate pest;
 
 use std::rc::Rc;
 
-use pest::inputs::{Input, Position, StringInput};
+use pest::inputs::{Input, Position, StrInput};
 use pest::iterators::{Pair, Pairs};
 use pest::{Error, Parser, ParserState, state};
 use pest::prec_climber::{Assoc, Operator, PrecClimber};
@@ -165,11 +165,11 @@ impl Parser<Rule> for CalculatorParser {
     }
 }
 
-fn consume(pair: Pair<Rule, StringInput>, climber: &PrecClimber<Rule>) -> i32 {
+fn consume(pair: Pair<Rule, StrInput>, climber: &PrecClimber<Rule>) -> i32 {
     let primary = |pair| {
         consume(pair, climber)
     };
-    let infix = |lhs: i32, op: Pair<Rule, StringInput>, rhs: i32| {
+    let infix = |lhs: i32, op: Pair<Rule, StrInput>, rhs: i32| {
         match op.as_rule() {
             Rule::plus => lhs + rhs,
             Rule::minus => lhs - rhs,

--- a/pest/tests/json.rs
+++ b/pest/tests/json.rs
@@ -381,17 +381,17 @@ impl Parser<Rule> for JsonParser {
 }
 
 #[derive(Debug, PartialEq)]
-enum Json<'a> {
+enum Json {
     Null,
     Bool(bool),
     Number(f64),
-    String(Span<StringInput<'a>>),
-    Array(Vec<Json<'a>>),
-    Object(HashMap<Span<StringInput<'a>>, Json<'a>>)
+    String(Span<StringInput>),
+    Array(Vec<Json>),
+    Object(HashMap<Span<StringInput>, Json>)
 }
 
-fn consume<'a>(pair: Pair<Rule, StringInput<'a>>) -> Json<'a> {
-    fn value<'a>(pair: Pair<Rule, StringInput<'a>>) -> Json<'a> {
+fn consume(pair: Pair<Rule, StringInput>) -> Json {
+    fn value(pair: Pair<Rule, StringInput>) -> Json {
         let pair = pair.into_inner().next().unwrap();
 
         match pair.as_rule() {

--- a/pest/tests/json.rs
+++ b/pest/tests/json.rs
@@ -381,17 +381,17 @@ impl Parser<Rule> for JsonParser {
 }
 
 #[derive(Debug, PartialEq)]
-enum Json {
+enum Json<'a> {
     Null,
     Bool(bool),
     Number(f64),
-    String(Span<StringInput>),
-    Array(Vec<Json>),
-    Object(HashMap<Span<StringInput>, Json>)
+    String(Span<StringInput<'a>>),
+    Array(Vec<Json<'a>>),
+    Object(HashMap<Span<StringInput<'a>>, Json<'a>>)
 }
 
-fn consume(pair: Pair<Rule, StringInput>) -> Json {
-    fn value(pair: Pair<Rule, StringInput>) -> Json {
+fn consume<'a>(pair: Pair<Rule, StringInput<'a>>) -> Json<'a> {
+    fn value<'a>(pair: Pair<Rule, StringInput<'a>>) -> Json<'a> {
         let pair = pair.into_inner().next().unwrap();
 
         match pair.as_rule() {


### PR DESCRIPTION
~~Fixes 141~~ 

Added support for `StringInput` to hold a borrowed `str`, as well as `String`. This is to avoid String copy in functions like `parse_str`.