### PR TITLE
Add cfg(debug_assertions) to suggested code

### DIFF
--- a/pest_derive/src/lib.rs
+++ b/pest_derive/src/lib.rs
@@ -26,6 +26,7 @@
 //! file can be included in a dummy `const` definition while debugging.
 //!
 //! ```ignore
+//! #[cfg(debug_assertions)]
 //! const _GRAMMAR: &'static str = include_str!("path/to/my_grammar.pest"); // relative to this file
 //!
 //! #[derive(Parser)]


### PR DESCRIPTION
That makes the dummy `const _GRAMMAR` be present only during development automatically, avoiding cases where one might forget to remove the line, or to simplify contributions / casual hacking, as there's no need to remember to add the line when editing the grammar.