### PR TITLE
Refer directly to SVGs in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://cdn.rawgit.com/pest-parser/pest/ac70b5c4/pest-logo.svg" width="80%"/>
+  <img src="pest-logo.svg" width="80%"/>
 </p>
 
 # pest. The Elegant Parser <sup>(beta)</sup>
@@ -125,7 +125,7 @@ the file to a fully-processed JSON object. The second one does, but since it has
 intermediate representation of the object, it repeats some work.
 
 <p align="center">
-  <img src="https://cdn.rawgit.com/pest-parser/pest/ac70b5c4/results.svg"/>
+  <img src="results.svg"/>
 </p>
 
 The [benchmark](https://github.com/Geal/pestvsnom) uses


### PR DESCRIPTION
GitHub will render SVGs referenced directly from the repo now! (this was a ridiculous amount of effort; see github/markup#556 if you're morbidly curious.) As a result:

* no need to route through another layer of CDN (i.e. rawgit's)
* because you don't need to specify the commit SHA in the URL, it'll automatically reflect the `pest-logo.svg` and `results.svg` of whatever commit/branch it's being shown on