### PR TITLE
Make README pairs example actually compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,19 @@ fn main() {
 
     // Because ident_list is silent, the iterator will contain idents
     for pair in pairs {
+
+        let span = pair.clone().into_span();
         // A pair is a combination of the rule which matched and a span of input
         println!("Rule:    {:?}", pair.as_rule());
-        println!("Span:    {:?}", pair.as_span());
-        println!("Text:    {}", pair.as_span().as_str());
+        println!("Span:    {:?}", span);
+        println!("Text:    {}", span.as_str());
 
         // A pair can be converted to an iterator of the tokens which make it up:
         for inner_pair in pair.into_inner() {
+            let inner_span = inner_pair.clone().into_span();
             match inner_pair.as_rule() {
-                Rule::alpha => println!("Letter:  {}", inner_pair.as_span().as_str()),
-                Rule::digit => println!("Digit:   {}", inner_pair.as_span().as_str()),
+                Rule::alpha => println!("Letter:  {}", inner_span.as_str()),
+                Rule::digit => println!("Digit:   {}", inner_span.as_str()),
                 _ => unreachable!()
             };
         }


### PR DESCRIPTION
There doesn't appear to be an `as_span` on `pest::iterators::Pair`, only an `into_span`. Without this change copy and pasting the README code doesn't compile, showing this error:

```
no method named `as_span` found for type `pest::iterators::Pair<'_, Rule>` in the current scope
```