### PR TITLE
Added a docstring and example to restore_on_err

### DIFF
--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -916,8 +916,8 @@ impl<'i, R: RuleType> ParserState<'i, R> {
     ///
     /// let input = "ab";
     /// let mut state: Box<pest::ParserState<Rule>> = pest::ParserState::new(input);
-    /// let mut result = state.restore_on_err( |state| state.stack_push( |state|
-    ///     state.match_string("a")).and_then( |state| state.match_string("a"))
+    /// let mut result = state.restore_on_err(|state| state.stack_push(|state|
+    ///     state.match_string("a")).and_then(|state| state.match_string("a"))
     /// );
     ///
     /// assert!(result.is_err());

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -903,7 +903,29 @@ impl<'i, R: RuleType> ParserState<'i, R> {
         }
     }
 
-    /// Restores the original state of the `ParserState` when `f` returns an `Err`.
+    /// Restores the original state of the `ParserState` when `f` returns an `Err`. Currently,
+    /// this method only restores the stack.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pest;
+    /// # #[allow(non_camel_case_types)]
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// enum Rule {}
+    ///
+    /// let input = "ab";
+    /// let mut state: Box<pest::ParserState<Rule>> = pest::ParserState::new(input);
+    /// let mut result = state.restore_on_err( |state| state.stack_push( |state|
+    ///     state.match_string("a")).and_then( |state| state.match_string("a"))
+    /// );
+    ///
+    /// assert!(result.is_err());
+    ///
+    /// // Since the the rule doesn't match, the "a" pushed to the stack will be removed.
+    /// let catch_panic = std::panic::catch_unwind(|| result.unwrap_err().stack_pop());
+    /// assert!(catch_panic.is_err());
+    /// ```
     #[inline]
     pub fn restore_on_err<F>(self: Box<Self>, f: F) -> ParseResult<Box<Self>>
     where

--- a/pest/src/stack.rs
+++ b/pest/src/stack.rs
@@ -100,6 +100,19 @@ mod test {
     use super::Stack;
 
     #[test]
+    fn snapshot_with_empty() {
+        let mut stack = Stack::new();
+
+        stack.snapshot();
+        // []
+        assert!(stack.is_empty());
+        // [0]
+        stack.push(0);
+        stack.restore();
+        assert!(stack.is_empty());
+    }
+
+    #[test]
     fn stack_ops() {
         let mut stack = Stack::new();
 

--- a/pest/src/stack.rs
+++ b/pest/src/stack.rs
@@ -23,7 +23,7 @@ impl<T: Clone> Stack<T> {
         Stack {
             ops: vec![],
             cache: vec![],
-            snapshots: vec![],
+            snapshots: vec![0],
             current_snapshot: 0
         }
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -135,11 +135,8 @@ impl Vm {
                     self.parse_expr(expr, state).and_then(|state| {
                         state.repeat(|state| {
                             state.sequence(|state| {
-                                self.skip(
-                                    state
-                                ).and_then(|state| {
-                                    self.parse_expr(expr, state)
-                                })
+                                self.skip(state)
+                                    .and_then(|state| self.parse_expr(expr, state))
                             })
                         })
                     })


### PR DESCRIPTION
I actually also discovered a subtle bug. Originally, the stack would never be restored to an empty state since snapshotting requires that the ops vec was modified at least once prior to snapshot. To fix this, I pre-seed the snapshots with 0