### PR TITLE
Update dependencies for `pest_derive`

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,8 +17,9 @@ proc-macro = true
 [dependencies]
 pest = { path = "../pest", version = "^2.0" }
 pest_meta = { path = "../meta", version = "^2.0" }
-quote = "^0.5"
-syn = "^0.13"
+proc-macro2 = "^0.4.4"
+quote = "^0.6.3"
+syn = "^0.14.1"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -264,6 +264,7 @@ extern crate pest;
 extern crate pest_meta;
 
 extern crate proc_macro;
+extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 extern crate syn;


### PR DESCRIPTION
Use patch number-sensitive version requirements because of the deprecated API present in `proc-macro2` 0.4.0..0.4.3 and both `quote` 0.6.0..0.6.2 and `syn` 0.14.0 use that API.