### PR TITLE
[WIP] Add regex terminal

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -21,6 +21,10 @@ proc-macro2 = "^0.4.4"
 quote = "^0.6.3"
 syn = "^0.14.1"
 
+[dev-dependencies]
+regex = "1"
+lazy_static = "1"
+
 [badges]
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }

--- a/derive/tests/grammar.pest
+++ b/derive/tests/grammar.pest
@@ -23,6 +23,7 @@ sequence_nested = { string ~ string }
 sequence_compound_nested = ${ sequence_nested }
 choice = { string | range }
 optional = { string? }
+regex = { r"\p{XID_START}\p{XID_CONTINUE}*" }
 repeat = { string* }
 repeat_atomic = @{ string* }
 repeat_once = { string+ }

--- a/derive/tests/grammar.rs
+++ b/derive/tests/grammar.rs
@@ -11,6 +11,11 @@
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
+extern crate regex;
+#[macro_use]
+extern crate lazy_static;
+
+const _GRAMMAR: &str = include_str!("grammar.pest");
 
 #[derive(Parser)]
 #[grammar = "../tests/grammar.pest"]
@@ -269,6 +274,18 @@ fn optional_empty() {
             optional(0, 0)
         ]
     };
+}
+
+#[test]
+fn regex() {
+    parses_to! {
+        parser: GrammarParser,
+        input: "نامهای",
+        rule: Rule::regex,
+        tokens: [
+            regex(0, 12)
+        ]
+    }
 }
 
 #[test]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -14,6 +14,8 @@ readme = "_README.md"
 maplit = "^1.0"
 pest = "^1.0"
 pest_derive = "^1.0"
+lazy_static = "1.0.1"
+regex = "1"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -29,6 +29,8 @@ pub enum Expr {
     Str(String),
     /// Matches an exact string, case insensitively (ASCII only), e.g. `^"a"`
     Insens(String),
+    /// Matches a string satisfying a regex, e.g. `r"\p{XID_START}\p{XID_CONTINUE}*"`
+    Regex(String),
     /// Matches one character in the range, e.g. `'a'..'z'`
     Range(String, String),
     /// Matches the rule with the given name, e.g. `a`

--- a/meta/src/grammar.pest
+++ b/meta/src/grammar.pest
@@ -35,7 +35,7 @@ non_atomic_modifier      = { "!" }
 expression =  { term ~ (infix_operator ~ term)* }
 term       =  { prefix_operator* ~ node ~ postfix_operator* }
 node       = _{ opening_paren ~ expression ~ closing_paren | terminal }
-terminal   = _{ _push | identifier | string | insensitive_string | range }
+terminal   = _{ _push | regex | identifier | string | insensitive_string | range }
 
 prefix_operator  = _{ positive_predicate_operator | negative_predicate_operator }
 infix_operator   = _{ sequence_operator | choice_operator }
@@ -76,6 +76,7 @@ string             = ${ quote ~ inner_str ~ quote }
 insensitive_string =  { "^" ~ string }
 range              =  { character ~ range_operator ~ character }
 character          = ${ single_quote ~ inner_chr ~ single_quote }
+regex              = ${ regex_head ~ inner_regex ~ regex_tail }
 
 inner_str = @{ (!("\"" | "\\") ~ any)* ~ (escape ~ inner_str)? }
 inner_chr = @{ escape | any }
@@ -83,6 +84,10 @@ escape    = @{ "\\" ~ ("\"" | "\\" | "r" | "n" | "t" | "0" | "'" | code | unicod
 code      = @{ "x" ~ hex_digit{2} }
 unicode   = @{ "u" ~ opening_brace ~ hex_digit{2, 6} ~ closing_brace }
 hex_digit = @{ '0'..'9' | 'a'..'f' | 'A'..'F' }
+
+regex_head  = @{ "r" ~ push("#"*) ~ "\"" }
+inner_regex = @{ (!("\"" ~ peek) ~ any)* }
+regex_tail  = @{ "\"" ~ pop }
 
 quote          = { "\"" }
 single_quote   = { "'" }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -15,6 +15,9 @@ extern crate pest;
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
+extern crate regex;
+#[macro_use]
+extern crate lazy_static;
 
 use std::fmt::Display;
 

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["parsing"]
 license = "MIT/Apache-2.0"
 readme = "_README.md"
 
+[dependencies]
+regex = "1"
+
 [badges]
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -56,6 +56,8 @@
 
 #![doc(html_root_url = "https://docs.rs/pest")]
 
+extern crate regex;
+
 pub use parser::Parser;
 pub use parser_state::{state, Atomicity, Lookahead, ParseResult, ParserState};
 pub use position::Position;

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -529,6 +529,14 @@ impl<'i, R: RuleType> ParserState<'i, R> {
         }
     }
 
+    pub fn match_regex(mut self: Box<Self>, regex: &::regex::Regex) -> ParseResult<Box<Self>> {
+        if self.position.match_regex(regex) {
+            Ok(self)
+        } else {
+            Err(self)
+        }
+    }
+
     /// Asks the `ParserState` to skip `n` `char`s. If the match is successful, this will return an
     /// `Ok` with the updated `Box<ParserState>`. If failed, an `Err` with the updated
     /// `Box<ParserState>` is returned.

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -348,6 +348,18 @@ impl<'i> Position<'i> {
             None => false
         }
     }
+
+    pub(crate) fn match_regex(&mut self, regex: &::regex::Regex) -> bool {
+        // guaranteed to be valid UTF-8
+        let slice = unsafe { str::from_utf8_unchecked(&self.input[self.pos..]) };
+        match regex.find(slice) {
+            Some(hit) => {
+                self.pos += hit.end();
+                true
+            }
+            None => false
+        }
+    }
 }
 
 impl<'i> fmt::Debug for Position<'i> {


### PR DESCRIPTION
This is a bit messy, and probably needs more tests. However, `pest_derive/tests/grammar::regex` does prove that the feature is functional. Closes #175. The given grammar would be written:

```pest
id          = { id1 ~ idn* }
id1         = { r"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]" }
idn         = { r"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]" }
```

Note that the author recommends the following [UAX31-R1](https://www.unicode.org/reports/tr31/#R1)-compliant grammar for identifiers instead:

```pest
identifier = { r"\p{XID_START}\p{XID_CONTINUE}*" }
```

A more complete modification-resiliant [UAX31-D1](https://www.unicode.org/reports/tr31/#D1) grammar is left as an exercise to the reader.

If everything is working as intended, publicly facing changes should be as follows:

- public dependency on `regex:^1` added
- when using a regex terminal,
  - peer dependency on `regex:^1` added
  - peer dependency on `lazy_static:^1` added
  - lazy static called `REGEXES` is added during the derive
- regex terminals are now available!
  - syntax: raw string like Rust's
    - that is, `"r" ~ push("#"*) ~ (!("\""~peek) ~ any)* ~ "\"" ~ pop`
  - the regex crate is used to test the given regex against the input
  - provides access to Unicode Properties [as per the regex crate documentation](https://github.com/rust-lang/regex/blob/master/UNICODE.md#rl12-properties)
- added `match_regex(Box<self>, &Regex)` method to `pest::ParserState`
  - (that's where the public dependency on `regex` comes in)

Any further publicly-visible changes are probably a bug in my implementation. Now accepting pointers on where I should add tests, any functionality I've missed (do I need to do something for `pest_vm`?), or stupid (or style) errors.