### PR TITLE
pest_derive does not work with quote = "0.3.14" so bump dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ pest requires [Cargo and Rust 1.23](https://www.rust-lang.org/en-US/downloads.ht
 Add the following to `Cargo.toml`:
 
 ```toml
-pest = "^1.0"
-pest_derive = "^1.0"
+pest = "1.0"
+pest_derive = "1.0"
 ```
 
 and in your Rust `lib.rs` or `main.rs`:

--- a/pest_derive/Cargo.toml
+++ b/pest_derive/Cargo.toml
@@ -15,9 +15,9 @@ name = "pest_derive"
 proc-macro = true
 
 [dependencies]
-quote = "^0.3"
-syn = "^0.11"
-pest = { path = "../pest", version = "^1.0" }
+quote = "0.3.15"
+syn = "0.11"
+pest = { path = "../pest", version = "1.0" }
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/pest_grammars/Cargo.toml
+++ b/pest_grammars/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 readme = "_README.md"
 
 [dependencies]
-pest = { path = "../pest", version = "^1.0" }
-pest_derive = { path = "../pest_derive", version = "^1.0" }
+pest = { path = "../pest", version = "1.0" }
+pest_derive = { path = "../pest_derive", version = "1.0" }
 
 [badges]
 codecov = { repository = "pest-parser/pest" }


### PR DESCRIPTION
In testing [`criterion` with Cargos `-Z minimal-versions`](https://github.com/japaric/criterion.rs/issues/183) I notestd that `pest_derive` does not work with quote = "<=0.3.14". This PR bumps the minimal acceptable versions in Cargo.toml to 0.3.15, so as to match what you are really compatible with.

This gets `pest.*` working with Cargos -Z minimal-versions. This is part of the process of seeing how hard minimal-versions is for crates to use in preparation for getting it stabilized for use in CI. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.