### PR TITLE
Removed skip from pest_keywords.

### DIFF
--- a/derive/src/macros.rs
+++ b/derive/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! generate_rule {
         quote! {
             #[inline]
             #[allow(dead_code, non_snake_case, unused_variables)]
-            fn $name(state: Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<Box<::pest::ParserState<Rule>>> {
+            pub fn $name(state: Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<Box<::pest::ParserState<Rule>>> {
                 $pattern
             }
         }

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -80,7 +80,6 @@ pub fn validate_pairs<'i>(pairs: Pairs<'i, Rule>) -> Result<Vec<&'i str>, Vec<Er
     pest_keywords.insert("POP");
     pest_keywords.insert("POP_ALL");
     pest_keywords.insert("PUSH");
-    pest_keywords.insert("skip");
     pest_keywords.insert("SOI");
 
     let mut builtins = HashSet::new();
@@ -807,6 +806,14 @@ mod tests {
   = expression cannot fail; following choices cannot be reached")]
     fn lhs_non_failing_nested_choices() {
         let input = "a = { b | \"a\" } b = { \"b\"* | \"c\" }";
+        unwrap_or_report(consume_rules(
+            PestParser::parse(Rule::grammar_rules, input).unwrap()
+        ));
+    }
+
+    #[test]
+    fn skip_can_be_defined() {
+        let input = "skip = { \"\" }";
         unwrap_or_report(consume_rules(
             PestParser::parse(Rule::grammar_rules, input).unwrap()
         ));


### PR DESCRIPTION
skip was reserved as a keyword due to an implementation detail. This new approach circumvents this need and permits its use as a rule.