### PR TITLE
pest_vm fixes

### DIFF
--- a/derive/src/generator.rs
+++ b/derive/src/generator.rs
@@ -81,12 +81,12 @@ pub fn generate(
 fn generate_builtin_rules() -> HashMap<&'static str, TokenStream> {
     let mut builtins = HashMap::new();
 
+    insert_builtin!(builtins, ANY, state.skip(1));
     insert_public_builtin!(
         builtins,
         EOI,
         state.rule(Rule::EOI, |state| state.end_of_input())
     );
-    insert_builtin!(builtins, ANY, state.skip(1));
     insert_builtin!(builtins, SOI, state.start_of_input());
     insert_builtin!(builtins, PEEK, state.stack_peek());
     insert_builtin!(builtins, PEEK_ALL, state.stack_match_peek());

--- a/derive/tests/grammar.pest
+++ b/derive/tests/grammar.pest
@@ -42,7 +42,7 @@ pop_all = { PUSH(range) ~ PUSH(range) ~ POP_ALL }
 pop_fail = { PUSH(range) ~ !POP ~ range ~ POP }
 checkpoint_restore = ${ PUSH("") ~ (PUSH("a") ~ "b" ~ POP | POP ~ "a") ~ EOI }
 unicode = { XID_START ~ XID_CONTINUE* }
-Symbol = { "shadows builtin" }
+SYMBOL = { "shadows builtin" }
 
 WHITESPACE = _{ " " }
 COMMENT = _{ "$"+ }

--- a/derive/tests/grammar.rs
+++ b/derive/tests/grammar.rs
@@ -779,9 +779,9 @@ fn shadowing() {
     parses_to! {
         parser: GrammarParser,
         input: "shadows builtin",
-        rule: Rule::Symbol,
+        rule: Rule::SYMBOL,
         tokens: [
-            Symbol(0, 15)
+            SYMBOL(0, 15)
         ]
     }
 }

--- a/pest/src/unicode/mod.rs
+++ b/pest/src/unicode/mod.rs
@@ -48,7 +48,7 @@ char_property_functions! {
     ];
 }
 
-pub fn by_name(name: &str) -> Option<Box<Fn(char) -> bool>> {println!("{:?}", name);
+pub fn by_name(name: &str) -> Option<Box<Fn(char) -> bool>> {
     for property in binary::BY_NAME {
         if name == property.0.to_uppercase() {
             return Some(Box::new(move |c| property.1.contains_char(c)));

--- a/pest/src/unicode/mod.rs
+++ b/pest/src/unicode/mod.rs
@@ -35,7 +35,7 @@ char_property_functions! {
         REGIONAL_INDICATOR, SENTENCE_TERMINAL, SOFT_DOTTED, TERMINAL_PUNCTUATION, UNIFIED_IDEOGRAPH,
         UPPERCASE, VARIATION_SELECTOR, WHITE_SPACE, XID_CONTINUE, XID_START,
     ];
-    
+
     mod category;
     [
         CASED_LETTER, CLOSE_PUNCTUATION, CONNECTOR_PUNCTUATION, CONTROL, CURRENCY_SYMBOL,
@@ -46,4 +46,20 @@ char_property_functions! {
         PRIVATE_USE, PUNCTUATION, SEPARATOR, SPACE_SEPARATOR, SPACING_MARK, SURROGATE, SYMBOL,
         TITLECASE_LETTER, UNASSIGNED, UPPERCASE_LETTER,
     ];
+}
+
+pub fn by_name(name: &str) -> Option<Box<Fn(char) -> bool>> {println!("{:?}", name);
+    for property in binary::BY_NAME {
+        if name == property.0.to_uppercase() {
+            return Some(Box::new(move |c| property.1.contains_char(c)));
+        }
+    }
+
+    for property in category::BY_NAME {
+        if name == property.0.to_uppercase() {
+            return Some(Box::new(move |c| property.1.contains_char(c)));
+        }
+    }
+
+    None
 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -53,7 +53,6 @@ impl Vm {
             "POP" => return state.stack_pop(),
             "POP_ALL" => return state.stack_match_pop(),
             "DROP" => return state.stack_drop(),
-
             "ASCII_DIGIT" => return state.match_range('0'..'9'),
             "ASCII_NONZERO_DIGIT" => return state.match_range('1'..'9'),
             "ASCII_BIN_DIGIT" => return state.match_range('0'..'1'),

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -13,6 +13,7 @@ extern crate pest_meta;
 use pest::{Atomicity, ParseResult, ParserState};
 use pest::error::Error;
 use pest::iterators::Pairs;
+use pest::unicode;
 use pest_meta::ast::RuleType;
 use pest_meta::optimizer::{OptimizedExpr, OptimizedRule};
 
@@ -44,12 +45,41 @@ impl Vm {
         state: Box<ParserState<'i, &'a str>>
     ) -> ParseResult<Box<ParserState<'i, &'a str>>> {
         match rule {
-            "any" => return state.skip(1),
+            "ANY" => return state.skip(1),
             "EOI" => return state.rule("EOI", |state| state.end_of_input()),
             "SOI" => return state.start_of_input(),
             "PEEK" => return state.stack_peek(),
+            "PEEK_ALL" => return state.stack_match_peek(),
             "POP" => return state.stack_pop(),
+            "POP_ALL" => return state.stack_match_pop(),
             "DROP" => return state.stack_drop(),
+
+            "ASCII_DIGIT" => return state.match_range('0'..'9'),
+            "ASCII_NONZERO_DIGIT" => return state.match_range('1'..'9'),
+            "ASCII_BIN_DIGIT" => return state.match_range('0'..'1'),
+            "ASCII_OCT_DIGIT" => return state.match_range('0'..'7'),
+            "ASCII_HEX_DIGIT" => {
+                return state.match_range('0'..'9')
+                    .or_else(|state| state.match_range('a'..'f'))
+                    .or_else(|state| state.match_range('A'..'F'))
+            },
+            "ASCII_ALPHA_LOWER" => return state.match_range('a'..'z'),
+            "ASCII_ALPHA_UPPER" => return state.match_range('A'..'Z'),
+            "ASCII_ALPHA" => {
+                return state.match_range('a'..'z')
+                    .or_else(|state| state.match_range('A'..'Z'))
+            },
+            "ASCII_ALPHANUMERIC" => {
+                return state.match_range('a'..'z')
+                    .or_else(|state| state.match_range('A'..'Z'))
+                    .or_else(|state| state.match_range('0'..'9'))
+            },
+            "ASCII" => return state.match_range('\x00'..'\x7f'),
+            "NEWLINE" => {
+                return state.match_string("\n")
+                    .or_else(|state| state.match_string("\r\n"))
+                    .or_else(|state| state.match_string("\r"))
+            },
             _ => ()
         };
 
@@ -98,6 +128,10 @@ impl Vm {
                 }
             }
         } else {
+            if let Some(property) = unicode::by_name(rule) {
+                return state.match_char_by(|c| property(c));
+            }
+
             panic!("undefined rule {}", rule);
         }
     }

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -168,11 +168,11 @@ macro_rules! parses_to {
                             &::pest::Token::End { rule: ref second_rule, .. }
                         ) => {
                             assert!(
-                                format!("{:?}", first_rule) == "eoi",
+                                format!("{}", first_rule) == "EOI",
                                 format!("expected end of input, but found {:?}", rest)
                             );
                             assert!(
-                                format!("{:?}", second_rule) == "eoi",
+                                format!("{}", second_rule) == "EOI",
                                 format!("expected end of input, but found {:?}", rest)
                             );
                         }

--- a/vm/tests/grammar.pest
+++ b/vm/tests/grammar.pest
@@ -36,9 +36,13 @@ repeat_max = { string{, 2} }
 repeat_max_atomic = @{ string{, 2} }
 repeat_mutate_stack = { (PUSH('a'..'c') ~ ",")* ~ POP ~ POP ~ POP }
 peek_ = { PUSH(range) ~ PUSH(range) ~ PEEK ~ PEEK }
+peek_all = { PUSH(range) ~ PUSH(range) ~ PEEK_ALL }
 pop_ = { PUSH(range) ~ PUSH(range) ~ POP ~ POP }
+pop_all = { PUSH(range) ~ PUSH(range) ~ POP_ALL }
 pop_fail = { PUSH(range) ~ !POP ~ range ~ POP }
 checkpoint_restore = ${ PUSH("") ~ (PUSH("a") ~ "b" ~ POP | POP ~ "a") ~ EOI }
+unicode = { XID_START ~ XID_CONTINUE* }
+SYMBOL = { "shadows builtin" }
 
 WHITESPACE = _{ " " }
 COMMENT = _{ "$"+ }

--- a/vm/tests/grammar.rs
+++ b/vm/tests/grammar.rs
@@ -687,6 +687,21 @@ fn peek() {
 }
 
 #[test]
+fn peek_all() {
+    parses_to! {
+        parser: vm(),
+        input: "0110",
+        rule: "peek_all",
+        tokens: [
+            peek_all(0, 4, [
+                range(0, 1),
+                range(1, 2)
+            ])
+        ]
+    };
+}
+
+#[test]
 fn pop() {
     parses_to! {
         parser: vm(),
@@ -694,6 +709,21 @@ fn pop() {
         rule: "pop_",
         tokens: [
             pop_(0, 4, [
+                range(0, 1),
+                range(1, 2)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn pop_all() {
+    parses_to! {
+        parser: vm(),
+        input: "0110",
+        rule: "pop_all",
+        tokens: [
+            pop_all(0, 4, [
                 range(0, 1),
                 range(1, 2)
             ])
@@ -738,4 +768,28 @@ fn checkpoint_restore() {
             checkpoint_restore(0, 1, [EOI(1, 1)])
         ]
     };
+}
+
+#[test]
+fn unicode() {
+    parses_to! {
+        parser: vm(),
+        input: "نامهای",
+        rule: "unicode",
+        tokens: [
+            unicode(0, 12)
+        ]
+    }
+}
+
+#[test]
+fn shadowing() {
+    parses_to! {
+        parser: vm(),
+        input: "shadows builtin",
+        rule: "SYMBOL",
+        tokens: [
+            SYMBOL(0, 15)
+        ]
+    }
 }

--- a/vm/tests/lists.pest
+++ b/vm/tests/lists.pest
@@ -1,0 +1,18 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+item = { (!"\n" ~ ANY)* }
+
+lists        = _{ lines ~ EOI }
+lines        = _{ top_first ~ ("\n" ~ top_continue)* }
+top_first    = _{ "- " ~ item ~ ("\n" ~ children)? }
+top_continue = _{ PEEK_ALL ~ "- " ~ item ~ ("\n" ~ children)? }
+
+indentation = _{ (" " | "\t")+ }
+children    =  { PEEK_ALL ~ PUSH(indentation) ~ lines ~ DROP }

--- a/vm/tests/lists.rs
+++ b/vm/tests/lists.rs
@@ -1,0 +1,129 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+extern crate pest;
+extern crate pest_meta;
+#[macro_use]
+extern crate pest_vm;
+
+use pest_meta::{optimizer, parser};
+use pest_meta::parser::Rule;
+use pest_vm::Vm;
+
+const GRAMMAR: &'static str = include_str!("lists.pest");
+
+fn vm() -> Vm {
+    let pairs = parser::parse(Rule::grammar_rules, GRAMMAR).unwrap();
+    let ast = parser::consume_rules(pairs).unwrap();
+    Vm::new(optimizer::optimize(ast))
+}
+
+#[test]
+fn item() {
+    parses_to! {
+        parser: vm(),
+        input: "- a",
+        rule: "lists",
+        tokens: [
+            item(2, 3)
+        ]
+    };
+}
+
+#[test]
+fn items() {
+    parses_to! {
+        parser: vm(),
+        input: "- a\n- b",
+        rule: "lists",
+        tokens: [
+            item(2, 3),
+            item(6, 7)
+        ]
+    };
+}
+
+#[test]
+fn children() {
+    parses_to! {
+        parser: vm(),
+        input: "  - b",
+        rule: "children",
+        tokens: [
+            children(0, 5, [
+                item(4, 5)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn nested_item() {
+    parses_to! {
+        parser: vm(),
+        input: "- a\n  - b",
+        rule: "lists",
+        tokens: [
+            item(2, 3),
+            children(4, 9, [
+                item(8, 9)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn nested_items() {
+    parses_to! {
+        parser: vm(),
+        input: "- a\n  - b\n  - c",
+        rule: "lists",
+        tokens: [
+            item(2, 3),
+            children(4, 15, [
+                item(8, 9),
+                item(14, 15)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn nested_two_levels() {
+    parses_to! {
+        parser: vm(),
+        input: "- a\n  - b\n    - c",
+        rule: "lists",
+        tokens: [
+            item(2, 3),
+            children(4, 17, [
+                item(8, 9),
+                children(10, 17, [
+                    item(16, 17)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn nested_then_not() {
+    parses_to! {
+        parser: vm(),
+        input: "- a\n  - b\n- c",
+        rule: "lists",
+        tokens: [
+            item(2, 3),
+            children(4, 9, [
+                item(8, 9)
+            ]),
+            item(12, 13)
+        ]
+    };
+}

--- a/vm/tests/reporting.pest
+++ b/vm/tests/reporting.pest
@@ -10,7 +10,7 @@
 a = { "a" }
 b = { "b" }
 c = { "c" }
-d = { any }
+d = { ANY }
 
 choices = _{ a | b | c }
 choices_no_progress = { a | b | c }
@@ -24,4 +24,3 @@ negative = _{ !d }
 negative_match = _{ !a ~ b }
 mixed = _{ !d | a }
 mixed_progress = _{ (!d | a | b) ~ a }
-


### PR DESCRIPTION
Brought `pest_vm` to parity with `pest_derive` and other fixes.

Should have tests in `grammar.pest` for all builtins.