### PR TITLE
Added preliminary SIMD optimization.

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,6 +14,9 @@ readme = "_README.md"
 name = "pest_derive"
 proc-macro = true
 
+[features]
+no_simd = []
+
 [dependencies]
 pest = { path = "../pest", version = "2.0" }
 pest_meta = { path = "../meta", version = "2.0" }

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -10,10 +10,15 @@ categories = ["parsing"]
 license = "MIT/Apache-2.0"
 readme = "_README.md"
 
+[features]
+default = ["packed_simd"]
+no_simd = []
+
 [badges]
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
 
 [dependencies]
+packed_simd = { version = "0.2", optional = true }
 ucd-trie = "0.1.1"

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -56,6 +56,8 @@
 
 #![doc(html_root_url = "https://docs.rs/pest")]
 
+#[cfg(not(feature = "no_std"))]
+extern crate packed_simd;
 extern crate ucd_trie;
 
 pub use parser::Parser;

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -623,6 +623,34 @@ impl<'i, R: RuleType> ParserState<'i, R> {
         }
     }
 
+    /// Asks the `ParserState` to continue to skip until one of the given `bytes` is found. If
+    /// the match is successful, this will return an `Ok` with the updated `Box<ParserState>`. If
+    /// failed, an `Err` with the updated `Box<ParserState>` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pest;
+    /// # #[allow(non_camel_case_types)]
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// enum Rule {}
+    ///
+    /// let input = "abcd";
+    /// let mut state: Box<pest::ParserState<Rule>> = pest::ParserState::new(input);
+    /// let mut result = state.skip_until_bytes(&[99, 100]); // c: 99, d: 100
+    /// assert!(result.is_ok());
+    /// assert_eq!(result.unwrap().position().pos(), 2);
+    /// ```
+    #[cfg(not(feature = "no_std"))]
+    #[inline]
+    pub fn skip_until_bytes(mut self: Box<Self>, bytes: &[u8]) -> ParseResult<Box<Self>> {
+        if self.position.skip_until_bytes(bytes) {
+            Ok(self)
+        } else {
+            Err(self)
+        }
+    }
+
     /// Asks the `ParserState` to match the start of the input. If the match is successful, this
     /// will return an `Ok` with the updated `Box<ParserState>`. If failed, an `Err` with the
     /// updated `Box<ParserState>` is returned.


### PR DESCRIPTION
Currently only kicks in in skip_until sequences, but this opens doors to a series of similar approaches.

Implementation relies on packed_simd which is why it is hidden behind a feature flag. Once this is stabilized and implemented in std, this feature can be removed.