### PR TITLE
Bootstrap pest_meta with pest:2.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+bootstrap = "run --package pest_bootstrap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ notifications:
 script:
   # Need a custom script because we are using cargo workspaces.
   - |
+      cargo bootstrap && # dynamic build dependency of pest_meta
       cargo build --all --verbose &&
       cargo test --all --verbose &&
       cargo doc --all --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "bootstrap",
     "derive",
     "generator",
     "grammars",

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -1,25 +1,19 @@
 [package]
-name = "pest_meta"
-description = "pest meta language parser and validator"
-version = "2.0.1"
+name = "pest_bootstrap"
+description = "pest bootstrap script"
+version = "0.0.0"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"
 documentation = "https://docs.rs/pest"
-keywords = ["pest", "parser", "meta", "optimizer"]
-categories = ["parsing"]
+publish = false
 license = "MIT/Apache-2.0"
-readme = "_README.md"
-exclude = ["src/grammar.pest"]
 
 [dependencies]
-maplit = "1.0"
-pest = { path = "../pest", version = "2.0" }
+pest_generator = "2.0" # Use the crates-io version, which (should be) known-good
+quote = "0.6.8"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
-
-[build-dependencies]
-sha-1 = "0.7.0"

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate quote;
+extern crate pest_generator;
+
+use pest_generator::derive_parser;
+use std::{fs::File, io::prelude::*, path::Path};
+
+fn main() {
+    let pest = Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../meta/src/grammar.pest"
+    ));
+    let rs = Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../meta/src/grammar.rs"
+    ));
+
+    let derived = {
+        let path = pest.to_string_lossy();
+        let pest = quote! {
+            #[grammar = #path]
+            pub struct PestParser;
+        };
+        derive_parser(pest, false)
+    };
+
+    let mut file = File::create(rs).unwrap();
+
+    writeln!(file, "pub struct PestParser;\n{}", derived,).unwrap();
+}

--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -1,0 +1,1 @@
+/src/grammar.rs

--- a/meta/build.rs
+++ b/meta/build.rs
@@ -1,0 +1,69 @@
+extern crate sha1;
+
+use sha1::{Digest, Sha1};
+use std::env;
+use std::fs::{self, File};
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+use std::process::{Command};
+
+fn display_digest(digest: &[u8]) -> String {
+    digest.iter()
+        .map(|byte| format!("{:02x}", byte))
+        .collect()
+}
+
+fn main() {
+    println!("rerun-if-changed=src/grammar.pest");
+
+    // Yes; build.rs is supposed to treat `src` as read-only; however:
+    // We want to publish `grammar.rs` and not `grammar.pest`,
+    // so putting it in `src` is the simplest way to do so.
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let grammar_pest_path = manifest_dir.join("src/grammar.pest");
+    let grammar_rs_path = manifest_dir.join("src/grammar.rs");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let hash_path = out_dir.join("pest_hash.sha1");
+
+    // If `grammar.pest` exists (we're building from git sources)
+    if grammar_pest_path.exists() {
+        let mut sha = Sha1::default();
+
+        let old_hash = File::open(&hash_path).ok().map(|mut file| {
+            let mut s = String::new();
+            file.read_to_string(&mut s).unwrap();
+            s
+        });
+        let current_grammar = fs::read_to_string(grammar_pest_path).unwrap();
+        sha.input(current_grammar.as_bytes());
+        let current_hash = display_digest(&sha.result());
+
+        // If `grammar.pest` has changed
+        if !grammar_rs_path.exists()
+            || old_hash.as_ref().map(|it| it.trim()) != Some(current_hash.trim())
+        {
+            println!("Bootstrapping `meta/src/grammar.rs`");
+
+            let mut hash_file = File::create(hash_path).unwrap();
+            writeln!(hash_file, "{}", current_hash).unwrap();
+
+            // This "dynamic linking" is probably so fragile I don't even want to hear it
+            let status = Command::new(manifest_dir.join("../target/debug/pest_bootstrap"))
+                .spawn().unwrap_or_else(|_| {
+                    panic!(
+                        "Bootstrap failed because no bootstrap executable was found. \
+                        Please run `cargo build --package pest_bootstrap` or `cargo bootstrap` \
+                        and then try again.",
+                    )
+                })
+                .wait().unwrap();
+            if !status.success() {
+                panic!("Bootstrap failed");
+            }
+        } else {
+            println!("       Fresh `meta/src/grammar.rs`");
+        }
+    } else {
+        assert!(grammar_rs_path.exists(), "package is broken; does not contain grammar.rs");
+    }
+}

--- a/meta/src/grammar.pest
+++ b/meta/src/grammar.pest
@@ -7,7 +7,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-grammar_rules = _{ soi ~ grammar_rule+ ~ eoi }
+grammar_rules = _{ SOI ~ grammar_rule+ ~ EOI }
 
 grammar_rule = {
     identifier ~ assignment_operator ~ modifier? ~
@@ -77,8 +77,8 @@ insensitive_string =  { "^" ~ string }
 range              =  { character ~ range_operator ~ character }
 character          = ${ single_quote ~ inner_chr ~ single_quote }
 
-inner_str = @{ (!("\"" | "\\") ~ any)* ~ (escape ~ inner_str)? }
-inner_chr = @{ escape | any }
+inner_str = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ inner_str)? }
+inner_chr = @{ escape | ANY }
 escape    = @{ "\\" ~ ("\"" | "\\" | "r" | "n" | "t" | "0" | "'" | code | unicode) }
 code      = @{ "x" ~ hex_digit{2} }
 unicode   = @{ "u" ~ opening_brace ~ hex_digit{2, 6} ~ closing_brace }
@@ -89,5 +89,5 @@ single_quote   = { "'" }
 range_operator = { ".." }
 
 newline    = _{ "\n" | "\r\n" }
-whitespace = _{ " " | "\t" | newline }
-comment    = _{ "//" ~ (!newline ~ any)* }
+WHITESPACE = _{ " " | "\t" | newline }
+COMMENT    = _{ "//" ~ (!newline ~ ANY)* }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -13,8 +13,6 @@ extern crate maplit;
 extern crate pest;
 #[cfg(not(test))]
 extern crate pest;
-#[macro_use]
-extern crate pest_derive;
 
 use std::fmt::Display;
 

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -12,11 +12,8 @@ use std::iter::Peekable;
 
 use pest::iterators::{Pair, Pairs};
 use pest::prec_climber::{Assoc, Operator, PrecClimber};
-use pest::Span;
-use pest::{
-    error::{Error, ErrorVariant},
-    Parser
-};
+use pest::{Span, Parser};
+use pest::error::{Error, ErrorVariant};
 
 use ast::{Expr, Rule as AstRule, RuleType};
 use validator;


### PR DESCRIPTION
Does the minimum amount to get `pest_meta` compiling against pest:2.0.

Run `cargo bootstrap` to regenerate `meta/grammar.rs` from `meta/grammar.pest`.
The bootstrap generated `.rs` is included so that downstream users don't have to bootstrap compile the pest grammar, thus the bootstrap recursion is broken.

Closes #288 