### PR TITLE
Fixed an optiomization bug.

### DIFF
--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -599,8 +599,7 @@ impl<'i, R: RuleType> ParserState<'i, R> {
     }
 
     /// Attempts to skip forward until one of the given strings is found. Returns `Ok` with the
-    /// updated `Box<ParserState>` if one of the strings is found, or `Err` with the updated
-    /// `Box<ParserState>` otherwise.
+    /// updated `Box<ParserState>` whether or not one of the strings is found.
     ///
     /// # Examples
     ///
@@ -618,11 +617,8 @@ impl<'i, R: RuleType> ParserState<'i, R> {
     /// ```
     #[inline]
     pub fn skip_until(mut self: Box<Self>, strings: &[&str]) -> ParseResult<Box<Self>> {
-        if self.position.skip_until(strings) {
-            Ok(self)
-        } else {
-            Err(self)
-        }
+        self.position.skip_until(strings);
+        Ok(self)
     }
 
     /// Attempts to match the start of the input. Returns `Ok` with the current `Box<ParserState>`

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -256,7 +256,7 @@ impl<'i> Position<'i> {
     }
 
     /// Skips until one of the given `strings` is found. If none of the `strings` can be found,
-    /// this function will return `false` and its `pos` will not be updated.
+    /// this function will return `false` but its `pos` will *still* be updated.
     #[inline]
     pub(crate) fn skip_until(&mut self, strings: &[&str]) -> bool {
         for from in self.pos..self.input.len() {
@@ -270,6 +270,7 @@ impl<'i> Position<'i> {
             }
         }
 
+        self.pos = self.input.len();
         false
     }
 
@@ -537,11 +538,7 @@ mod tests {
 
         test_pos = pos.clone();
         assert!(!test_pos.skip_until(&["z"]));
-        assert_eq!(test_pos.pos(), 0);
-
-        test_pos = pos.clone();
-        assert!(!test_pos.skip_until(&["zzz"]));
-        assert_eq!(test_pos.pos(), 0);
+        assert_eq!(test_pos.pos(), 5);
     }
 
     #[test]


### PR DESCRIPTION
The skip optimization was wrongly failing when the search patterns were not found before the end of input.