### PR TITLE
Set up bors-ng 

### DIFF
--- a/.bors.toml
+++ b/.bors.toml
@@ -1,0 +1,3 @@
+status = [
+    "continuous-integration/travis-ci/push",
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ git:
   depth: 1
 branches:
   only:
+    - staging
+    - trying
     - master
 notifications:
   email: false


### PR DESCRIPTION
https://bors.tech/

Requires the bors integration to have access to the organization to do its work; I've requested permission on its behalf. This is merely a suggestion, but I've had great success using bors on personal projects even without multiple PRs in flight at the same time, even just as a merge-when-green bot.