### PR TITLE
Pairs::peek

### DIFF
--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -167,6 +167,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         tokens::new(self.queue, self.input, self.start, self.end)
     }
 
+    /// Peek at the first inner `Pair` without changing the position of this iterator.
     #[inline]
     pub fn peek(&self) -> Option<Pair<'i, R>> {
         if self.start < self.end {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -168,7 +168,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     }
 
     #[inline]
-    pub fn peek(&mut self) -> Option<<Self as Iterator>::Item> {
+    pub fn peek(&mut self) -> Option<Pair> {
         if self.start < self.end {
             Some(pair::new(Rc::clone(&self.queue), self.input, self.start))
         } else {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -174,9 +174,6 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         } else {
             None
         }
-        if self.start >= self.end {
-            return None;
-        }
     }
 
     fn pair(&self) -> usize {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -167,6 +167,18 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         tokens::new(self.queue, self.input, self.start, self.end)
     }
 
+    #[inline]
+    pub fn peek(&mut self) -> Option<<Self as Iterator>::Item> {
+        if self.start < self.end {
+            Some(pair::new(Rc::clone(&self.queue), self.input, self.start))
+        } else {
+            None
+        }
+        if self.start >= self.end {
+            return None;
+        }
+    }
+
     fn pair(&self) -> usize {
         match self.queue[self.start] {
             QueueableToken::Start {
@@ -198,14 +210,8 @@ impl<'i, R: RuleType> Iterator for Pairs<'i, R> {
     type Item = Pair<'i, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.start >= self.end {
-            return None;
-        }
-
-        let pair = pair::new(Rc::clone(&self.queue), self.input, self.start);
-
+        let pair = self.peek()?;
         self.start = self.pair() + 1;
-
         Some(pair)
     }
 }

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -168,7 +168,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     }
 
     #[inline]
-    pub fn peek(&mut self) -> Option<Pair<'i, R>> {
+    pub fn peek(&self) -> Option<Pair<'i, R>> {
         if self.start < self.end {
             Some(pair::new(Rc::clone(&self.queue), self.input, self.start))
         } else {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -168,7 +168,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     }
 
     #[inline]
-    pub fn peek(&mut self) -> Option<Pair> {
+    pub fn peek(&mut self) -> Option<Pair<'i, R>> {
         if self.start < self.end {
             Some(pair::new(Rc::clone(&self.queue), self.input, self.start))
         } else {


### PR DESCRIPTION
How does `next_back` work? Would a `peek_back` be useful to have (for completeness?)?