### PR TITLE
Generate dummy grammar include in release mode too.

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -154,12 +154,11 @@ fn generate_builtin_rules() -> HashMap<&'static str, TokenStream> {
     builtins
 }
 
-// Needed because Cargo doesn't watch for changes in grammers.
+// Needed because Cargo doesn't watch for changes in grammars.
 fn generate_include(name: &Ident, path: &str) -> TokenStream {
     let const_name = Ident::new(&format!("_PEST_GRAMMAR_{}", name), Span::call_site());
     quote! {
         #[allow(non_upper_case_globals)]
-        #[cfg(debug_assertions)]
         const #const_name: &'static str = include_str!(#path);
     }
 }
@@ -904,7 +903,6 @@ mod tests {
             generate(name, &generics, Path::new("test.pest"), rules, defaults, true).to_string(),
             quote! {
                 #[allow(non_upper_case_globals)]
-                #[cfg(debug_assertions)]
                 const _PEST_GRAMMAR_MyParser: &'static str = include_str!("test.pest");
 
                 #[allow(dead_code, non_camel_case_types)]


### PR DESCRIPTION
The conditional was probably added because it was in the original
hint to do this manually in the documentation.  There doesn't seem
to be a downside since the constant will be thrown away in any
case, being unused.

Fixes #320.