### PR TITLE
meta: include README and LICENSE files in the package

### DIFF
--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["parsing"]
 license = "MIT/Apache-2.0"
 readme = "_README.md"
 exclude = ["src/grammar.pest"]
-include = ["Cargo.toml", "src/**/*", "src/grammar.rs"]
+include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"]
 
 [dependencies]
 maplit = "1.0"

--- a/meta/LICENSE-APACHE
+++ b/meta/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/meta/LICENSE-MIT
+++ b/meta/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
The README is nice to have, and LICENSE-APACHE might not be strictly required,
but LICENSE-MIT requires that it "shall be included".