### PR TITLE
Add conversion Pair -> Pairs (iter::once)

### DIFF
--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -248,6 +248,14 @@ impl<'i, R: RuleType> Pair<'i, R> {
     }
 }
 
+impl<'i, R: RuleType> Pairs<'i, R> {
+    /// Create a new `Pairs` iterator containing just the single `Pair`.
+    pub fn single(pair: Pair<'i, R>) -> Self {
+        let end = pair.pair();
+        pairs::new(pair.queue, pair.input, pair.start, end)
+    }
+}
+
 impl<'i, R: RuleType> fmt::Debug for Pair<'i, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Pair")


### PR DESCRIPTION
[Mentioned in the gitter channel](https://gitter.im/pest-parser/pest?at=5be61fe87326df140ee00980), `PrecClimber` hands outs `Pair` (as it should) and `FromPest` (in [pest-parser/ast](https://github.com/pest-parser/ast)'s `from-pest`) takes `&mut Pairs`.

This causes a problem where the current `from-pest` design (taking a mutable iterator cursor) isn't compatible with using a `PrecClimber`.

This patch gives `Pairs` the equivalent of `iter::once`, creating an iterator of a single `Pair` from said `Pair`. This makes it possible to then hand this new iterator to the `FromPest` implementation.