### PR TITLE
Fix error display if pos is after \n

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -137,7 +137,7 @@ impl<R: RuleType> Error<R> {
     #[allow(clippy::needless_pass_by_value)]
     pub fn new_from_span(variant: ErrorVariant<R>, span: Span) -> Error<R> {
         let end = span.end_pos();
-        
+
         let mut end_line_col = end.line_col();
         // end position is after a \n, so we want to point to the visual lf symbol
         if end_line_col.1 == 1 {
@@ -146,7 +146,7 @@ impl<R: RuleType> Error<R> {
             let lc = visual_end.line_col();
             end_line_col = (lc.0, lc.1 + 1);
         };
-        
+
         let mut line_iter = span.lines();
         let start_line = visualize_whitespace(line_iter.next().unwrap_or(""));
         let continued_line = line_iter.last().map(visualize_whitespace);
@@ -157,7 +157,7 @@ impl<R: RuleType> Error<R> {
             path: None,
             line: start_line,
             continued_line,
-            line_col: LineColLocation::Span(span.start_pos().line_col(), end_line_col)
+            line_col: LineColLocation::Span(span.start_pos().line_col(), end_line_col),
         }
     }
 
@@ -672,9 +672,9 @@ mod tests {
 
         let error: Error<u32> = Error::new_from_span(
             ErrorVariant::CustomError {
-                message: "error: big one".to_owned()
+                message: "error: big one".to_owned(),
             },
-            start.span(&end)
+            start.span(&end),
         );
 
         assert_eq!(
@@ -686,7 +686,8 @@ mod tests {
                 "  | ^-----^",
                 "  |",
                 "  = error: big one",
-            ].join("\n")
+            ]
+            .join("\n")
         );
     }
 
@@ -700,9 +701,9 @@ mod tests {
 
         let error: Error<u32> = Error::new_from_span(
             ErrorVariant::CustomError {
-                message: "error: empty".to_owned()
+                message: "error: empty".to_owned(),
             },
-            start.span(&end)
+            start.span(&end),
         );
 
         assert_eq!(
@@ -714,7 +715,8 @@ mod tests {
                 "  | ^",
                 "  |",
                 "  = error: empty",
-            ].join("\n")
+            ]
+            .join("\n")
         );
     }
 

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -684,6 +684,34 @@ mod tests {
     }
 
     #[test]
+    fn display_custom_span_empty() {
+        let input = "";
+        let start = position::Position::new(input, 0).unwrap();
+        let end = position::Position::new(input, 0).unwrap();
+        assert!(start.at_start());
+        assert!(end.at_end());
+
+        let error: Error<u32> = Error::new_from_span(
+            ErrorVariant::CustomError {
+                message: "error: empty".to_owned()
+            },
+            start.span(&end)
+        );
+
+        assert_eq!(
+            format!("{}", error),
+            vec![
+                " --> 1:1",
+                "  |",
+                "1 | ",
+                "  | ^",
+                "  |",
+                "  = error: empty",
+            ].join("\n")
+        );
+    }
+
+    #[test]
     fn mapped_parsing_error() {
         let input = "ab\ncd\nef";
         let pos = position::Position::new(input, 4).unwrap();

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -100,7 +100,7 @@ impl<R: RuleType> Error<R> {
             variant,
             location: InputLocation::Pos(pos.pos()),
             path: None,
-            line: pos.line_of().to_owned(),
+            line: visualize_whitespace(pos.line_of()),
             continued_line: None,
             line_col: LineColLocation::Pos(pos.line_col()),
         }
@@ -148,8 +148,8 @@ impl<R: RuleType> Error<R> {
         };
         
         let mut line_iter = span.lines();
-        let start_line = line_iter.next().unwrap_or("".to_owned());
-        let continued_line = line_iter.last();
+        let start_line = visualize_whitespace(line_iter.next().unwrap_or(""));
+        let continued_line = line_iter.last().map(visualize_whitespace);
 
         Error {
             variant,
@@ -440,6 +440,10 @@ impl<'i, R: RuleType> error::Error for Error<R> {
             ErrorVariant::CustomError { ref message } => message,
         }
     }
+}
+
+fn visualize_whitespace(input: &str) -> String {
+    input.to_owned().replace('\r', "␍").replace('\n', "␊")
 }
 
 #[cfg(test)]

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -148,7 +148,7 @@ impl<R: RuleType> Error<R> {
         };
         
         let mut line_iter = span.lines();
-        let start_line = line_iter.next().unwrap_or_else(|| "".to_owned());
+        let start_line = line_iter.next().unwrap_or("".to_owned());
         let continued_line = line_iter.last();
 
         Error {

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -64,7 +64,7 @@ extern crate ucd_trie;
 pub use parser::Parser;
 pub use parser_state::{state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState};
 pub use position::Position;
-pub use span::{Span, Lines};
+pub use span::{Lines, Span};
 use std::fmt::Debug;
 use std::hash::Hash;
 pub use token::Token;

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -64,7 +64,7 @@ extern crate ucd_trie;
 pub use parser::Parser;
 pub use parser_state::{state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState};
 pub use position::Position;
-pub use span::Span;
+pub use span::{Span, Lines};
 use std::fmt::Debug;
 use std::hash::Hash;
 pub use token::Token;

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -285,6 +285,28 @@ impl<'i> Position<'i> {
         true
     }
 
+    /// Goes back `n` `char`s from the `Position` and returns `true` if the skip was possible or `false`
+    /// otherwise. If the return value is `false`, `pos` will not be updated.
+    #[inline]
+    pub(crate) fn skip_back(&mut self, n: usize) -> bool {
+        let skipped = {
+            let mut len = 0;
+            // Position's pos is always a UTF-8 border.
+            let mut chars = (&self.input[..self.pos]).chars().rev();
+            for _ in 0..n {
+                if let Some(c) = chars.next() {
+                    len += c.len_utf8();
+                } else {
+                    return false;
+                }
+            }
+            len
+        };
+
+        self.pos -= skipped;
+        true
+    }
+
     /// Skips until one of the given `strings` is found. If none of the `strings` can be found,
     /// this function will return `false` but its `pos` will *still* be updated.
     #[inline]

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -194,13 +194,12 @@ impl<'i> Position<'i> {
     /// assert_eq!(result.unwrap().position().line_of(), "a");
     /// ```
     #[inline]
-    pub fn line_of(&self) -> String {
+    pub fn line_of(&self) -> &'i str {
         if self.pos > self.input.len() {
             panic!("position out of bounds");
         };
         // Safe since start and end can only be valid UTF-8 borders.
-        let line = &self.input[self.find_line_start()..self.find_line_end()];
-        line.to_owned().replace('\r', "␍").replace('\n', "␊")
+        &self.input[self.find_line_start()..self.find_line_end()]
     }
     
     pub(crate) fn find_line_start(&self) -> usize {
@@ -464,13 +463,13 @@ mod tests {
     fn line_of() {
         let input = "a\rb\nc\r\nd嗨";
 
-        assert_eq!(Position::new(input, 0).unwrap().line_of(), "a␍b␊");
-        assert_eq!(Position::new(input, 1).unwrap().line_of(), "a␍b␊");
-        assert_eq!(Position::new(input, 2).unwrap().line_of(), "a␍b␊");
-        assert_eq!(Position::new(input, 3).unwrap().line_of(), "a␍b␊");
-        assert_eq!(Position::new(input, 4).unwrap().line_of(), "c␍␊");
-        assert_eq!(Position::new(input, 5).unwrap().line_of(), "c␍␊");
-        assert_eq!(Position::new(input, 6).unwrap().line_of(), "c␍␊");
+        assert_eq!(Position::new(input, 0).unwrap().line_of(), "a\rb\n");
+        assert_eq!(Position::new(input, 1).unwrap().line_of(), "a\rb\n");
+        assert_eq!(Position::new(input, 2).unwrap().line_of(), "a\rb\n");
+        assert_eq!(Position::new(input, 3).unwrap().line_of(), "a\rb\n");
+        assert_eq!(Position::new(input, 4).unwrap().line_of(), "c\r\n");
+        assert_eq!(Position::new(input, 5).unwrap().line_of(), "c\r\n");
+        assert_eq!(Position::new(input, 6).unwrap().line_of(), "c\r\n");
         assert_eq!(Position::new(input, 7).unwrap().line_of(), "d嗨");
         assert_eq!(Position::new(input, 8).unwrap().line_of(), "d嗨");
         assert_eq!(Position::new(input, 11).unwrap().line_of(), "d嗨");
@@ -487,14 +486,14 @@ mod tests {
     fn line_of_new_line() {
         let input = "\n";
 
-        assert_eq!(Position::new(input, 0).unwrap().line_of(), "␊");
+        assert_eq!(Position::new(input, 0).unwrap().line_of(), "\n");
     }
 
     #[test]
     fn line_of_between_new_line() {
         let input = "\n\n";
 
-        assert_eq!(Position::new(input, 1).unwrap().line_of(), "␊");
+        assert_eq!(Position::new(input, 1).unwrap().line_of(), "\n");
     }
 
     fn measure_skip(input: &str, pos: usize, n: usize) -> Option<usize> {

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -201,21 +201,24 @@ impl<'i> Position<'i> {
         // Safe since start and end can only be valid UTF-8 borders.
         &self.input[self.find_line_start()..self.find_line_end()]
     }
-    
+
     pub(crate) fn find_line_start(&self) -> usize {
-        if self.input.is_empty() { return 0 };
+        if self.input.is_empty() {
+            return 0;
+        };
         // Position's pos is always a UTF-8 border.
-        let start = self.input
+        let start = self
+            .input
             .char_indices()
             .rev()
             .skip_while(|&(i, _)| i >= self.pos)
             .find(|&(_, c)| c == '\n');
         match start {
             Some((i, _)) => i + 1,
-            None => 0
+            None => 0,
         }
     }
-    
+
     pub(crate) fn find_line_end(&self) -> usize {
         if self.input.is_empty() {
             0
@@ -230,7 +233,7 @@ impl<'i> Position<'i> {
                 .find(|&(_, c)| c == '\n');
             match end {
                 Some((i, _)) => i + 1,
-                None => self.input.len()
+                None => self.input.len(),
             }
         }
     }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -196,7 +196,7 @@ impl<'i> Span<'i> {
     /// let start_pos = state.position().clone();
     /// state = state.match_string("b\nc").unwrap();
     /// let span = start_pos.span(&state.position().clone());
-    /// assert_eq!(span.lines().collect(), vec!["b\n", "c"]);
+    /// assert_eq!(span.lines().collect::<Vec<_>>(), vec!["b\n", "c"]);
     /// ```
     #[inline]
     pub fn lines(&self) -> Lines {
@@ -230,9 +230,11 @@ impl<'i> Hash for Span<'i> {
     }
 }
 
-/// Line iterator for Spans
+/// Line iterator for Spans, created by [`Span::lines()`].
 /// 
 /// Iterates all lines that are at least partially covered by the span.
+/// 
+/// [`Span::lines()`]: struct.Span.html#method.lines
 pub struct Lines<'i> {
     span: &'i Span<'i>,
     pos: usize,

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -182,9 +182,9 @@ impl<'i> Span<'i> {
     }
 
     /// Iterates over all lines (partially) covered by this span.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use pest;
     /// # #[allow(non_camel_case_types)]
@@ -200,7 +200,10 @@ impl<'i> Span<'i> {
     /// ```
     #[inline]
     pub fn lines(&self) -> Lines {
-        Lines { span: self, pos: self.start }
+        Lines {
+            span: self,
+            pos: self.start,
+        }
     }
 }
 
@@ -231,9 +234,9 @@ impl<'i> Hash for Span<'i> {
 }
 
 /// Line iterator for Spans, created by [`Span::lines()`].
-/// 
+///
 /// Iterates all lines that are at least partially covered by the span.
-/// 
+///
 /// [`Span::lines()`]: struct.Span.html#method.lines
 pub struct Lines<'i> {
     span: &'i Span<'i>,
@@ -243,9 +246,13 @@ pub struct Lines<'i> {
 impl<'i> Iterator for Lines<'i> {
     type Item = &'i str;
     fn next(&mut self) -> Option<&'i str> {
-        if self.pos > self.span.end { return None }
+        if self.pos > self.span.end {
+            return None;
+        }
         let pos = position::Position::new(self.span.input, self.pos)?;
-        if pos.at_end() { return None }
+        if pos.at_end() {
+            return None;
+        }
         let line = pos.line_of();
         self.pos = pos.find_line_end();
         Some(line)


### PR DESCRIPTION
I had to add an API for moving a position back.

An alternative would have been to modify `skip_while` to take a slice of `std::str::pattern::Pattern`s instead of `&[&str]` and add a `skip_back_while` function that does the same but backwards. Then we could have skipped back until we hit a non-newline character.

Should I do that instead?

Fixes #348