### PR TITLE
Enforce minimal versions CI gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
       script: cargo tarpaulin --verbose --skip-clean --out Xml
       after_success: bash <(curl -s https://codecov.io/bash)
   allow_failures:
-    - name: minimal versions # Remove once it passes :D
     - name: coverage # So builds don't have to wait on it
   fast_finish: true
 

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 license = "MIT/Apache-2.0"
 
 [dependencies]
-pest_generator = "2.0.1" # Use the crates-io version, which (should be) known-good
+pest_generator = "2.1.0" # Use the crates-io version, which (should be) known-good
 quote = "0.6.8"
 
 [badges]

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 license = "MIT/Apache-2.0"
 
 [dependencies]
-pest_generator = "2.0" # Use the crates-io version, which (should be) known-good
+pest_generator = "2.0.1" # Use the crates-io version, which (should be) known-good
 quote = "0.6.8"
 
 [badges]


### PR DESCRIPTION
Bump bootstrap to use generator:2.0.1 and stop allowing failures for the minimum-versions CI job.

Merge once generator:2.0.1 is published.