### PR TITLE
Removing deprecated method calls from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,16 @@ fn main() {
 
     // Because ident_list is silent, the iterator will contain idents
     for pair in pairs {
-
-        let span = pair.clone().into_span();
         // A pair is a combination of the rule which matched and a span of input
         println!("Rule:    {:?}", pair.as_rule());
-        println!("Span:    {:?}", span);
-        println!("Text:    {}", span.as_str());
+        println!("Span:    {:?}", pair.as_span());
+        println!("Text:    {}", pair.as_str());
 
         // A pair can be converted to an iterator of the tokens which make it up:
         for inner_pair in pair.into_inner() {
-            let inner_span = inner_pair.clone().into_span();
             match inner_pair.as_rule() {
-                Rule::alpha => println!("Letter:  {}", inner_span.as_str()),
-                Rule::digit => println!("Digit:   {}", inner_span.as_str()),
+                Rule::alpha => println!("Letter:  {}", inner_pair.as_str()),
+                Rule::digit => println!("Digit:   {}", inner_pair.as_str()),
                 _ => unreachable!()
             };
         }


### PR DESCRIPTION
The readme file contained calls to ['Pair::into_span'](https://docs.rs/pest/2.1.0/pest/iterators/struct.Pair.html#method.into_span), witch were deprecated in 2.0.0.

I have replaced calls to ['into_span'](https://docs.rs/pest/2.1.0/pest/iterators/struct.Pair.html#method.into_span) with ['as_span'](https://docs.rs/pest/2.1.0/pest/iterators/struct.Pair.html#method.as_span), as well as calling ['pair::as_str'](https://docs.rs/pest/2.1.0/pest/iterators/struct.Pair.html#method.as_str) directly instead of the ['span::as_str'](https://docs.rs/pest/2.1.0/pest/struct.Span.html#method.as_str).

This is my first pull request to any open source project. So I hope I've done this right :sweat_smile: