### PR TITLE
Adding HTTP grammar

### DIFF
--- a/grammars/src/grammars/http.pest
+++ b/grammars/src/grammars/http.pest
@@ -1,0 +1,13 @@
+http = _{ SOI ~ request* ~ EOI }
+request = { request_line ~ header+ ~ NEWLINE }
+
+request_line = { token ~ " "+ ~ request_target ~ " "+ ~ "HTTP/" ~ version ~ NEWLINE }
+request_target = { (!" " ~ ANY)+ }
+version = { (ASCII_DIGIT | ".")+ }
+
+header = { token ~ ":" ~ h_space+ ~ header_value+ ~ NEWLINE }
+header_value = { (!NEWLINE ~ ANY)+ }
+
+h_space = { " " | "\t" }
+token = { (!separator ~ ANY)+ }
+separator = { " " | "\"" | "," | "/" | ":" | ";" | "=" | "?" | "@" | "\\" | "(" | ")" | "<" | ">" | "[" | "]" | "{" | "}" }

--- a/grammars/src/lib.rs
+++ b/grammars/src/lib.rs
@@ -19,6 +19,13 @@ extern crate pest_derive;
 
 pub use pest::Parser;
 
+pub mod http {
+    /// HTTP parser.
+    #[derive(Parser)]
+    #[grammar = "grammars/http.pest"]
+    pub struct HttpParser;
+}
+
 pub mod json {
     /// JSON parser.
     #[derive(Parser)]


### PR DESCRIPTION
I've tried to make a http request grammar file, as mentioned in [#210](https://github.com/pest-parser/pest/issues/210). It doen't restrict the allowed characters in tokens as much as they should be, as I don't know how to properly express the range of allowed characters.
It is currently untested as I don't have much experience with the format, and don't quite know what I should and shouldn't test.