### PR TITLE
Allow accessing the line and path of a `pest::error::Error` struct

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -13,6 +13,7 @@ use std::cmp;
 use std::error;
 use std::fmt;
 use std::mem;
+use std::path;
 
 use position::Position;
 use span::Span;
@@ -244,6 +245,16 @@ impl<R: RuleType> Error<R> {
         self.variant = variant;
 
         self
+    }
+
+    /// Returns the path to the file that raised the error, if any.
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_ref().map(String::as_str)
+    }
+
+    /// Return the line that raised the error.
+    pub fn line(&self) -> &str {
+        self.line.as_str()
     }
 
     fn start(&self) -> (usize, usize) {

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -13,7 +13,6 @@ use std::cmp;
 use std::error;
 use std::fmt;
 use std::mem;
-use std::path;
 
 use position::Position;
 use span::Span;


### PR DESCRIPTION
Hi !

First of all, many thanks for this library which is awesome to use.

I am currently using `pest` as a backend for a Python extension (using [`pyo3`](https://github.com/PyO3/pyo3) to generate the bindings), and as such, I wanted to transparently map a `pest::error::Error` to a Python `SyntaxError`. Since the proper signature for a `SyntaxError` is:
```python
SyntaxError("error message", ("path/to/file", line, col, "the exact line\n"))
```
it seems that `Error` already has all that I need, but privately !

This PR adds an accessor for the `path` and `line` fields of `Error`. I would also benefit from having the `message` method public :wink: 