### PR TITLE
Enforce -D warnings on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       - rustup component add rustfmt
       before_script: cargo bootstrap
       script:
-      - cargo clippy --all -- -D warnings
+      - cargo clippy --all --tests -- -D warnings
       - cargo fmt --all -- --check
     - name: minimal versions
       rust: nightly-2018-12-08 # Arbitrary nightly for unstable cargo feature -- make this MSRV build later?

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -187,7 +187,7 @@ fn consume_rules_with_spans<'i>(
         .map(|pair| {
             let mut pairs = pair.into_inner().peekable();
 
-            let span = pairs.next().unwrap().into_span();
+            let span = pairs.next().unwrap().as_span();
             let name = span.as_str().to_owned();
 
             pairs.next().unwrap(); // assignment_operator
@@ -235,7 +235,7 @@ fn consume_expr<'i>(
 
                 ParserNode {
                     expr: node.expr,
-                    span: pair.into_span().start_pos().span(&end),
+                    span: pair.as_span().start_pos().span(&end),
                 }
             }
             Rule::positive_predicate_operator => {
@@ -244,7 +244,7 @@ fn consume_expr<'i>(
 
                 ParserNode {
                     expr: ParserExpr::PosPred(Box::new(node)),
-                    span: pair.into_span().start_pos().span(&end),
+                    span: pair.as_span().start_pos().span(&end),
                 }
             }
             Rule::negative_predicate_operator => {
@@ -253,14 +253,14 @@ fn consume_expr<'i>(
 
                 ParserNode {
                     expr: ParserExpr::NegPred(Box::new(node)),
-                    span: pair.into_span().start_pos().span(&end),
+                    span: pair.as_span().start_pos().span(&end),
                 }
             }
             other_rule => {
                 let node = match other_rule {
                     Rule::expression => consume_expr(pair.into_inner().peekable(), climber)?,
                     Rule::_push => {
-                        let start = pair.clone().into_span().start_pos();
+                        let start = pair.as_span().start_pos();
                         let mut pairs = pair.into_inner();
                         pairs.next().unwrap(); // opening_paren
                         let pair = pairs.next().unwrap();
@@ -296,36 +296,36 @@ fn consume_expr<'i>(
                         };
                         ParserNode {
                             expr: ParserExpr::PeekSlice(start, end),
-                            span: pair.into_span(),
+                            span: pair.as_span(),
                         }
                     }
                     Rule::identifier => ParserNode {
                         expr: ParserExpr::Ident(pair.as_str().to_owned()),
-                        span: pair.clone().into_span(),
+                        span: pair.as_span(),
                     },
                     Rule::string => {
                         let string = unescape(pair.as_str()).expect("incorrect string literal");
                         ParserNode {
                             expr: ParserExpr::Str(string[1..string.len() - 1].to_owned()),
-                            span: pair.clone().into_span(),
+                            span: pair.as_span(),
                         }
                     }
                     Rule::insensitive_string => {
                         let string = unescape(pair.as_str()).expect("incorrect string literal");
                         ParserNode {
                             expr: ParserExpr::Insens(string[2..string.len() - 1].to_owned()),
-                            span: pair.clone().into_span(),
+                            span: pair.as_span(),
                         }
                     }
                     Rule::range => {
                         let mut pairs = pair.into_inner();
                         let pair = pairs.next().unwrap();
                         let start = unescape(pair.as_str()).expect("incorrect char literal");
-                        let start_pos = pair.clone().into_span().start_pos();
+                        let start_pos = pair.as_span().start_pos();
                         pairs.next();
                         let pair = pairs.next().unwrap();
                         let end = unescape(pair.as_str()).expect("incorrect char literal");
-                        let end_pos = pair.clone().into_span().end_pos();
+                        let end_pos = pair.as_span().end_pos();
 
                         ParserNode {
                             expr: ParserExpr::Range(
@@ -348,21 +348,21 @@ fn consume_expr<'i>(
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::Opt(Box::new(node)),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_operator => {
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::Rep(Box::new(node)),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_once_operator => {
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::RepOnce(Box::new(node)),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_exact => {
@@ -378,7 +378,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "number cannot overflow u32".to_owned(),
                                         },
-                                        number.into_span(),
+                                        number.as_span(),
                                     )]);
                                 };
 
@@ -387,7 +387,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "cannot repeat 0 times".to_owned(),
                                         },
-                                        number.into_span(),
+                                        number.as_span(),
                                     );
 
                                     return Err(vec![error]);
@@ -396,7 +396,7 @@ fn consume_expr<'i>(
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::RepExact(Box::new(node), num),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_min => {
@@ -412,14 +412,14 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "number cannot overflow u32".to_owned(),
                                         },
-                                        min_number.into_span(),
+                                        min_number.as_span(),
                                     )]);
                                 };
 
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::RepMin(Box::new(node), min),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_max => {
@@ -436,7 +436,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "number cannot overflow u32".to_owned(),
                                         },
-                                        max_number.into_span(),
+                                        max_number.as_span(),
                                     )]);
                                 };
 
@@ -445,7 +445,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "cannot repeat 0 times".to_owned(),
                                         },
-                                        max_number.into_span(),
+                                        max_number.as_span(),
                                     );
 
                                     return Err(vec![error]);
@@ -454,7 +454,7 @@ fn consume_expr<'i>(
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::RepMax(Box::new(node), max),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::repeat_min_max => {
@@ -470,7 +470,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "number cannot overflow u32".to_owned(),
                                         },
-                                        min_number.into_span(),
+                                        min_number.as_span(),
                                     )]);
                                 };
 
@@ -484,7 +484,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "number cannot overflow u32".to_owned(),
                                         },
-                                        max_number.into_span(),
+                                        max_number.as_span(),
                                     )]);
                                 };
 
@@ -493,7 +493,7 @@ fn consume_expr<'i>(
                                         ErrorVariant::CustomError {
                                             message: "cannot repeat 0 times".to_owned(),
                                         },
-                                        max_number.into_span(),
+                                        max_number.as_span(),
                                     );
 
                                     return Err(vec![error]);
@@ -502,7 +502,7 @@ fn consume_expr<'i>(
                                 let start = node.span.start_pos();
                                 ParserNode {
                                     expr: ParserExpr::RepMinMax(Box::new(node), min, max),
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             Rule::closing_paren => {
@@ -510,7 +510,7 @@ fn consume_expr<'i>(
 
                                 ParserNode {
                                     expr: node.expr,
-                                    span: start.span(&pair.into_span().end_pos()),
+                                    span: start.span(&pair.as_span().end_pos()),
                                 }
                             }
                             _ => unreachable!(),

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -109,7 +109,7 @@ pub fn validate_pairs<'i>(pairs: Pairs<'i, Rule>) -> Result<Vec<&'i str>, Vec<Er
     let definitions: Vec<_> = pairs
         .clone()
         .filter(|pair| pair.as_rule() == Rule::grammar_rule)
-        .map(|pair| pair.into_inner().next().unwrap().into_span())
+        .map(|pair| pair.into_inner().next().unwrap().as_span())
         .collect();
     let called_rules: Vec<_> = pairs
         .clone()
@@ -119,7 +119,7 @@ pub fn validate_pairs<'i>(pairs: Pairs<'i, Rule>) -> Result<Vec<&'i str>, Vec<Er
                 .flatten()
                 .skip(1)
                 .filter(|pair| pair.as_rule() == Rule::identifier)
-                .map(|pair| pair.into_span())
+                .map(|pair| pair.as_span())
         })
         .collect();
 

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -135,7 +135,7 @@ impl<'i, R: RuleType> Pair<'i, R> {
     /// #     state.rule(Rule::ab, |s| s.match_string("ab"))
     /// }).unwrap().next().unwrap();
     ///
-    /// assert_eq!(pair.into_span().as_str(), "ab");
+    /// assert_eq!(pair.as_span().as_str(), "ab");
     /// ```
     #[inline]
     #[deprecated(since = "2.0.0", note = "Please use `as_span` instead")]


### PR DESCRIPTION
We had a lot of `Pair::into_span` hanging around, including some `.clone().into_span()`.

Additionally, the code compiled for `cargo bootstrap` isn't clippy-checked, so that will need addressing at a later point.

r? @dragostis 