### PR TITLE
Implementation of `one-or-more` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Digit:   2
 * [tera](https://github.com/Keats/tera)
 * [ui_gen](https://github.com/emoon/ui_gen)
 * [ukhasnet-parser](https://github.com/adamgreig/ukhasnet-parser)
+* [prisma](https://github.com/prisma/prisma)
 
 ## Special thanks
 

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -450,6 +450,27 @@ fn generate_expr(expr: OptimizedExpr) -> TokenStream {
                 })
             }
         }
+
+        OptimizedExpr::RepOnce(expr) => {
+            let expr = generate_expr(*expr);
+
+            quote! {
+                state.sequence(|state| {
+                    #expr.and_then(|state| {
+                        state.repeat(|state| {
+                            state.sequence(|state| {
+                                super::hidden::skip(
+                                    state
+                                ).and_then(|state| {
+                                    #expr
+                                })
+                            })
+                        })
+                    })
+                })
+            }
+        }
+
         OptimizedExpr::Skip(strings) => {
             quote! {
                 let strings = [#(#strings),*];
@@ -582,6 +603,23 @@ fn generate_expr_atomic(expr: OptimizedExpr) -> TokenStream {
                 })
             }
         }
+
+        OptimizedExpr::RepOnce(expr) => {
+            let expr = generate_expr_atomic(*expr);
+   
+            quote! {
+                state.sequence(|state| {
+                    #expr.and_then(|state| {
+                        state.repeat(|state| {
+                            state.sequence(|state| {
+                                #expr
+                            })
+                        })
+                    })
+                })
+            }
+        }
+
         OptimizedExpr::Skip(strings) => {
             quote! {
                 let strings = [#(#strings),*];

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -606,7 +606,7 @@ fn generate_expr_atomic(expr: OptimizedExpr) -> TokenStream {
 
         OptimizedExpr::RepOnce(expr) => {
             let expr = generate_expr_atomic(*expr);
-   
+
             quote! {
                 state.sequence(|state| {
                     #expr.and_then(|state| {

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -63,7 +63,7 @@ fn rule_to_optimized_rule(rule: Rule) -> OptimizedRule {
             Expr::Rep(expr) => OptimizedExpr::Rep(Box::new(to_optimized(*expr))),
             Expr::Skip(strings) => OptimizedExpr::Skip(strings),
             Expr::Push(expr) => OptimizedExpr::Push(Box::new(to_optimized(*expr))),
-            Expr::RepOnce(_)
+            Expr::RepOnce(expr) => OptimizedExpr::RepOnce(Box::new(to_optimized(*expr))),
             | Expr::RepExact(..)
             | Expr::RepMin(..)
             | Expr::RepMax(..)
@@ -105,6 +105,7 @@ pub enum OptimizedExpr {
     Choice(Box<OptimizedExpr>, Box<OptimizedExpr>),
     Opt(Box<OptimizedExpr>),
     Rep(Box<OptimizedExpr>),
+    RepOnce(Box<OptimizedExpr>),
     Skip(Vec<String>),
     Push(Box<OptimizedExpr>),
     RestoreOnErr(Box<OptimizedExpr>),

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -64,10 +64,9 @@ fn rule_to_optimized_rule(rule: Rule) -> OptimizedRule {
             Expr::Skip(strings) => OptimizedExpr::Skip(strings),
             Expr::Push(expr) => OptimizedExpr::Push(Box::new(to_optimized(*expr))),
             Expr::RepOnce(expr) => OptimizedExpr::RepOnce(Box::new(to_optimized(*expr))),
-            | Expr::RepExact(..)
-            | Expr::RepMin(..)
-            | Expr::RepMax(..)
-            | Expr::RepMinMax(..) => unreachable!("No valid transformation to OptimizedRule"),
+            Expr::RepExact(..) | Expr::RepMin(..) | Expr::RepMax(..) | Expr::RepMinMax(..) => {
+                unreachable!("No valid transformation to OptimizedRule")
+            }
         }
     }
 

--- a/meta/src/optimizer/unroller.rs
+++ b/meta/src/optimizer/unroller.rs
@@ -15,7 +15,6 @@ pub fn unroll(rule: Rule) -> Rule {
             name,
             ty,
             expr: expr.map_bottom_up(|expr| match expr {
-              //  Expr::RepOnce(expr) => Expr::Seq(expr.clone(), Box::new(Expr::Rep(expr))),
                 Expr::RepExact(expr, num) => (1..num + 1)
                     .map(|_| *expr.clone())
                     .rev()

--- a/meta/src/optimizer/unroller.rs
+++ b/meta/src/optimizer/unroller.rs
@@ -15,7 +15,7 @@ pub fn unroll(rule: Rule) -> Rule {
             name,
             ty,
             expr: expr.map_bottom_up(|expr| match expr {
-                Expr::RepOnce(expr) => Expr::Seq(expr.clone(), Box::new(Expr::Rep(expr))),
+              //  Expr::RepOnce(expr) => Expr::Seq(expr.clone(), Box::new(Expr::Rep(expr))),
                 Expr::RepExact(expr, num) => (1..num + 1)
                     .map(|_| *expr.clone())
                     .rev()

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -186,6 +186,16 @@ impl Vm {
                     })
                 })
             }),
+            OptimizedExpr::RepOnce(ref expr) => state.sequence(|state| {
+                self.parse_expr(expr, state).and_then(|state| {
+                    state.repeat(|state| {
+                        state.sequence(|state| {
+                            self.skip(state)
+                                .and_then(|state| self.parse_expr(expr, state))
+                        })
+                    })
+                })
+            }),
             OptimizedExpr::Push(ref expr) => state.stack_push(|state| self.parse_expr(expr, state)),
             OptimizedExpr::Skip(ref strings) => state.skip_until(
                 &strings


### PR DESCRIPTION
Properly implements a rule for RepOnce, instead of translating it to `x ~ x*`. This solves the whitespace issue described in #396.