### PR TITLE
Don't enable std feature on sha-1

### DIFF
--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -23,4 +23,4 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
 
 [build-dependencies]
-sha-1 = "0.8"
+sha-1 = { version = "0.8", default-features = false }


### PR DESCRIPTION
I'm currently working on a no_std project that uses Pest in a proc macro, and also uses sha1 somewhere else in the crate graph. It uses sha1 in nostd mode. But because cargo ~~sucks~~ has [some really broken behavior](https://github.com/rust-lang/cargo/issues/4866) around build and dev dependencies, pest ends up activating the std feature for my build.

Pest doesn't really need the std feature of SHA-1 anyways. So this PR disables it.