### PR TITLE
Automated fuzzing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ cache: cargo
 os:
   - linux
 
-matrix:
+services:
+  - docker
+
+jobs:
   include:
     - name: stable
       rust: stable
@@ -36,6 +39,21 @@ matrix:
       before_script: cargo bootstrap
       script: cargo tarpaulin --verbose --out Xml --ciserver travis-ci
       after_success: bash <(curl -s https://codecov.io/bash)
+    - stage: Fuzz regression
+      rust: nightly
+      dist: bionic
+      script:
+        - cargo install --list | grep cargo-fuzz || cargo install cargo-fuzz
+        - cargo bootstrap
+        - ./fuzzit.sh local-regression
+    - stage: Fuzz
+      if: branch = master AND type IN (push)
+      rust: nightly
+      dist: bionic
+      script:
+        - cargo install --list | grep cargo-fuzz || cargo install cargo-fuzz
+        - cargo bootstrap
+        - ./fuzzit.sh fuzzing
   allow_failures:
     - name: coverage # So builds don't have to wait on it
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 [![Build Status](https://travis-ci.org/pest-parser/pest.svg?branch=master)](https://travis-ci.org/pest-parser/pest)
 [![codecov](https://codecov.io/gh/pest-parser/pest/branch/master/graph/badge.svg)](https://codecov.io/gh/pest-parser/pest)
+[![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=pest-parser)](https://app.fuzzit.dev/orgs/pest-parser/dashboard)
 [![Crates.io](https://img.shields.io/crates/d/pest.svg)](https://crates.io/crates/pest)
 [![Crates.io](https://img.shields.io/crates/v/pest.svg)](https://crates.io/crates/pest)
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -xe
+
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+if [ -z "$FUZZIT_API_KEY" ]; then
+    echo "Set FUZZIT_API_KEY to your Fuzzit API key"
+    exit 2
+fi
+
+# Configure
+NAME=pest
+TYPE=$1
+ROOT=`pwd`
+
+# Setup
+if [ ! -f fuzzit ]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
+
+# Fuzz
+function fuzz {
+    FUZZER=$1
+    TARGET=$NAME${2:+-$2}
+    DIR=${3:-.}
+    (
+        cd $DIR
+        cargo fuzz run $FUZZER -- -runs=0
+        $ROOT/fuzzit create job --type $TYPE $TARGET ./fuzz/target/x86_64-unknown-linux-gnu/debug/$FUZZER
+    )
+}
+fuzz parser parse meta
+fuzz toml toml grammars
+fuzz json json grammars


### PR DESCRIPTION
Hi guys. Really nice how you have some fuzz targets. What about running them automatically on Fuzzit?

This patch sets it up. All 3 targets are fuzzed. There's a [successful run](https://travis-ci.org/bookmoons/pest/builds/577269637) under my Travis account.

The PR build will fail due to missing an API key. Setup is like this:
* In [Fuzzit](https://fuzzit.dev/) create the targets `pest-parse` `pest-toml` `pest-json`.
* In Fuzzit settings grab an API key. In repo settings in [Travis](https://travis-ci.org/) paste it to `FUZZIT_API_KEY`.