### PR TITLE
Fixed build.

### DIFF
--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 license = "MIT/Apache-2.0"
 
 [dependencies]
-pest_generator = "2.1.0" # Use the crates-io version, which (should be) known-good
-quote = "0.6.8"
+pest_generator = "2.1.1" # Use the crates-io version, which (should be) known-good
+quote = "1.0"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }


### PR DESCRIPTION
bootstrap failed to build because it was depending on an older version of the generator. Fixes #424.