### PR TITLE
Remove HashMap from derive/generate

### DIFF
--- a/generator/src/macros.rs
+++ b/generator/src/macros.rs
@@ -9,13 +9,13 @@
 
 macro_rules! insert_builtin {
     ($builtin: expr, $name: ident, $pattern: expr) => {
-        $builtin.insert(stringify!($name), generate_rule!($name, $pattern));
+        $builtin.push((stringify!($name), generate_rule!($name, $pattern)));
     };
 }
 
 macro_rules! insert_public_builtin {
     ($builtin: expr, $name: ident, $pattern: expr) => {
-        $builtin.insert(stringify!($name), generate_public_rule!($name, $pattern));
+        $builtin.push((stringify!($name), generate_public_rule!($name, $pattern)));
     };
 }
 


### PR DESCRIPTION
There is a lot of value in outputs produced by compilers being
reproducible. Rust makes it somewhat hard to get it right, but most of
the time rustc’s outputs are also reproducible. This allows us to enjoy
all the benefits as other more primitive toolchains. Most of the time.

Pest was, sadly, one of those examples where reproducibility was not a
concern and HashMap was used to implement some of the  code generation
portions. Replacing this `HashMap` with a `Vec` and a `O(nm)` loop is
the easy solution. With the values that `n` and `m` get substituted with
in practice, however, this loop should still be approximately as good as
the previous `HashMap` implementation.