### PR TITLE
Silence non_upper_case_globals warnings

### DIFF
--- a/pest/src/prec_climber.rs
+++ b/pest/src/prec_climber.rs
@@ -88,6 +88,7 @@ macro_rules! prec_climber {
         $( [ $( $rules:ident )* ] )*
     ) => {
         $(
+            #[allow(non_upper_case_globals)]
             const $rule: u32 = $precedence;
         )*
         prec_climber!(


### PR DESCRIPTION
I'm really sorry for not catching this earlier, I assumed they were not considered globals by the linter when enclosed in their own scope and the doctest doesn't seem to emit any warnings for me, I even tried denying all warnings for it. Now I tested it in a real project and all of my tests there work as expected without any warnings.