### PR TITLE
Makes include_str! use a relative path

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -935,12 +935,14 @@ mod tests {
             expr: OptimizedExpr::Str("b".to_owned()),
         }];
         let defaults = vec!["ANY"];
-
+        let mut current_dir = std::env::current_dir().expect("Unable to get current directory");
+        current_dir.push("test.pest");
+        let test_path = current_dir.to_str().expect("path contains invalid unicode");
         assert_eq!(
             generate(name, &generics, Some(PathBuf::from("test.pest")), rules, defaults, true).to_string(),
             quote! {
                 #[allow(non_upper_case_globals)]
-                const _PEST_GRAMMAR_MyParser: &'static str = include_str!("test.pest");
+                const _PEST_GRAMMAR_MyParser: &'static str = include_str!(#test_path);
 
                 #[allow(dead_code, non_camel_case_types)]
                 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -166,9 +166,14 @@ fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
 // Needed because Cargo doesn't watch for changes in grammars.
 fn generate_include(name: &Ident, path: &str) -> TokenStream {
     let const_name = Ident::new(&format!("_PEST_GRAMMAR_{}", name), Span::call_site());
+    // Need to make this relative to the current directory since the path to the file
+    // is derived from the CARGO_MANIFEST_DIR environment variable
+    let mut current_dir = std::env::current_dir().expect("Unable to get current directory");
+    current_dir.push(path);
+    let relative_path = current_dir.to_str().expect("path contains invalid unicode");
     quote! {
         #[allow(non_upper_case_globals)]
-        const #const_name: &'static str = include_str!(#path);
+        const #const_name: &'static str = include_str!(#relative_path);
     }
 }
 


### PR DESCRIPTION
In situations where `CARGO_MANIFEST_DIR` is set atypically, pest can break it's grammar file finding