### PR TITLE
Fix build after PR #454

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -9,11 +9,11 @@
 
 //! Types for different kinds of parsing failures.
 
+use std::borrow::Cow;
 use std::cmp;
 use std::error;
 use std::fmt;
 use std::mem;
-use std::borrow::Cow;
 
 use position::Position;
 use span::Span;
@@ -430,9 +430,9 @@ impl<R: RuleType> ErrorVariant<R> {
     ///
     /// Returns the error message for [`ErrorVariant`]
     ///
-    /// If [`ErrorVariant`] is [`CustomError`], it returns a 
+    /// If [`ErrorVariant`] is [`CustomError`], it returns a
     /// [`Cow::Borrowed`] reference to [`message`]. If [`ErrorVariant`] is [`ParsingError`], a
-    /// [`Cow::Owned`] containing "expected [positives] [negatives]" is returned. 
+    /// [`Cow::Owned`] containing "expected [positives] [negatives]" is returned.
     ///
     /// [`ErrorVariant`]: enum.ErrorVariant.html
     /// [`CustomError`]: enum.ErrorVariant.html#variant.CustomError
@@ -454,7 +454,9 @@ impl<R: RuleType> ErrorVariant<R> {
             ErrorVariant::ParsingError {
                 ref positives,
                 ref negatives,
-            } => Cow::Owned(Error::parsing_error_message(positives, negatives, |r| format!("{:?}", r))),
+            } => Cow::Owned(Error::parsing_error_message(positives, negatives, |r| {
+                format!("{:?}", r)
+            })),
             ErrorVariant::CustomError { ref message } => Cow::Borrowed(message),
         }
     }

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -444,7 +444,7 @@ impl<R: RuleType> ErrorVariant<R> {
     ///
     /// ```
     /// # use pest::error::ErrorVariant;
-    /// let variant = ErrorVariant::CustomError {
+    /// let variant = ErrorVariant::<()>::CustomError {
     ///     message: String::from("unexpected error")
     /// };
     ///


### PR DESCRIPTION
PR #454 broke the build by adding a doctest that doesn't compile, in particular it gave the following error:

```
failures:

---- src/error.rs - error::ErrorVariant<R>::message (line 445) stdout ----
error[E0282]: type annotations needed for `pest::error::ErrorVariant<R>`
 --> src/error.rs:447:15
  |
5 | let variant = ErrorVariant::CustomError {
  |     -------   ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `R` declared on the enum `ErrorVariant`
  |     |
  |     consider giving `variant` the explicit type `pest::error::ErrorVariant<R>`, where the type parameter `R` is specified

error: aborting due to previous error

For more information about this error, try `rustc --explain E0282`.
Couldn't compile the test.

failures:
    src/error.rs - error::ErrorVariant<R>::message (line 445)

test result: FAILED. 59 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out
```

This error made PRs #470's and #473's bors build fail. After this PR is merged bors should be re-run for them.