### PR TITLE
Bump minimal-versions test version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       - cargo clippy --all -- -D warnings
       - cargo fmt --all -- --check
     - name: minimal versions
-      rust: nightly-2018-12-08 # Arbitrary nightly for unstable cargo feature -- make this MSRV build later?
+      rust: nightly-2019-11-01 # Arbitrary nightly for unstable cargo feature -- make this MSRV build later?
       before_script:
         - cargo -Z minimal-versions generate-lockfile
         - cargo bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         cargo test --all --verbose &&
         cargo doc --all --verbose
     - name: style
-      rust: 1.31.0 # Pinned warnings
+      rust: 1.47.0 # Pinned warnings
       install:
       - rustup component add clippy
       - rustup component add rustfmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       - cargo clippy --all -- -D warnings
       - cargo fmt --all -- --check
     - name: minimal versions
-      rust: nightly-2019-11-01 # Arbitrary nightly for unstable cargo feature -- make this MSRV build later?
+      rust: nightly-2020-01-01 # Arbitrary nightly for unstable cargo feature -- make this MSRV build later?
       before_script:
         - cargo -Z minimal-versions generate-lockfile
         - cargo bootstrap


### PR DESCRIPTION
cc @SkiFire13 

We've never promised MSRV support, and the "minimal versions" build is just to make sure that our toml is actually requesting a version that we build on. So because of this, I'm just bumping the arbitrary nightly to a later arbitrary nightly (that hopefully is somewhat recent enough?); specifically, ~~I bumped the version by just under a year, so it's again about a year back from current~~.

Hopefully this fixes the build.

bors: r+