### PR TITLE
Conditional source-tree bootstrapping

### DIFF
--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -17,3 +17,8 @@ quote = "1.0"
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
+
+[features]
+# Whether or not the bootstrapper should put the generated .rs file in the
+# source tree or in the output tree
+bootstrap-in-src = []

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -3,17 +3,22 @@ extern crate quote;
 extern crate pest_generator;
 
 use pest_generator::derive_parser;
-use std::{fs::File, io::prelude::*, path::Path};
+use std::{fs::File, io::prelude::*, env, path::{Path, PathBuf}};
 
 fn main() {
     let pest = Path::new(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../meta/src/grammar.pest"
     ));
-    let rs = Path::new(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../meta/src/grammar.rs"
-    ));
+    let rs = if should_bootstrap_in_src() {
+        PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../meta/src/grammar.rs"
+        ))
+    } else {
+        // the path is passed via command-line arguments
+        PathBuf::from(&env::args().nth(1).unwrap())
+    };
 
     let derived = {
         let path = pest.to_string_lossy();
@@ -25,6 +30,11 @@ fn main() {
     };
 
     let mut file = File::create(rs).unwrap();
-
     writeln!(file, "pub struct PestParser;\n{}", derived,).unwrap();
 }
+
+#[cfg(feature = "bootstrap-in-src")]
+fn should_bootstrap_in_src() -> bool { true }
+
+#[cfg(not(feature = "bootstrap-in-src"))]
+fn should_bootstrap_in_src() -> bool { false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -24,3 +24,6 @@ pest_generator = { path = "../generator", version = "2.1.0" }
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
+
+[features]
+bootstrap-in-src = ["pest_generator/bootstrap-in-src"]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -22,3 +22,6 @@ syn = "1.0"
 codecov = { repository = "pest-parser/pest" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "pest-parser/pest" }
+
+[features]
+bootstrap-in-src = ["pest_meta/bootstrap-in-src"]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -24,3 +24,4 @@ travis-ci = { repository = "pest-parser/pest" }
 
 [build-dependencies]
 sha-1 = { version = "0.9", default-features = false }
+cargo = "0.51.0"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -25,3 +25,6 @@ travis-ci = { repository = "pest-parser/pest" }
 [build-dependencies]
 sha-1 = { version = "0.9", default-features = false }
 cargo = "0.51.0"
+
+[features]
+bootstrap-in-src = []

--- a/meta/build.rs
+++ b/meta/build.rs
@@ -69,7 +69,7 @@ fn main() {
             let workspace = Workspace::new(&workspace_manifest, &config).unwrap();
 
             let mut opts = CompileOptions::new(&config, CompileMode::Build).unwrap();
-            opts.spec = Packages::Packages(vec!["bootstrap".to_owned()]);
+            opts.spec = Packages::Packages(vec!["pest_bootstrap".to_owned()]);
             ops::compile(&workspace, &opts).unwrap();
         } else {
             println!("       Fresh `meta/src/grammar.rs`");

--- a/meta/build.rs
+++ b/meta/build.rs
@@ -76,7 +76,9 @@ fn main() {
 
             let mut opts = CompileOptions::new(&config, CompileMode::Build).unwrap();
             opts.spec = Packages::Packages(vec!["pest_bootstrap".to_owned()]);
-            opts.features = vec!["bootstrap-in-src".to_owned()];
+            if should_bootstrap_in_src() {
+                opts.features = vec!["bootstrap-in-src".to_owned()];
+            }
             opts.build_config.requested_profile = InternedString::new("bootstrap");
 
             let path = if should_bootstrap_in_src() {
@@ -101,4 +103,3 @@ fn should_bootstrap_in_src() -> bool { true }
 
 #[cfg(not(feature = "bootstrap-in-src"))]
 fn should_bootstrap_in_src() -> bool { false }
->>>>>>> 838adc9 (more bootstrapping logic)

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -18,7 +18,11 @@ use pest::{Parser, Span};
 use ast::{Expr, Rule as AstRule, RuleType};
 use validator;
 
+#[cfg(feature = "bootstrap-in-src")]
 include!("grammar.rs");
+
+#[cfg(not(feature = "bootstrap-in-src"))]
+include!(concat!(env!("OUT_DIR"), "/__pest_grammar.rs"));
 
 pub fn parse(rule: Rule, data: &str) -> Result<Pairs<Rule>, Error<Rule>> {
     PestParser::parse(rule, data)


### PR DESCRIPTION
I ran into a problem when depending on my own patched version of pest, where I noticed that the bootstrapping scheme breaks when depending on source versions of pest that aren't fetched from crates.io. This is because bootstrapping creates a `grammar.rs` file in the source tree for pushing to `crates.io`, which is checked for by `meta/build.rs`. I looked at #376 and #424 (which is less relevant) but I think this patch solves some of the problems involved:

- When depending on a git version, the `meta` crate bootstraps by running `bootstrap` crate _using Cargo_ as a library. Since it's running with Cargo, the crate will be built if it doesn't exist, bypassing the hardcoded `target/debug/bootstrap` path that currently exists in the `build.rs` file. **This is the default,** since the majority of users aren't pushing to crates.io.
- When publishing to crates.io, it's preferable to have the `grammar.rs` file in the source tree, so that crates.io users won't have to bootstrap from source themselves (and also seeding for future versions of pest). To do this, pass the `--features bootstrap-in-src` flag when running the `bootstrap` crate. This will use the original logic and dump the `grammar.rs` file in the `meta/src` directory. I think there's a Cargo.toml field that you can use to always enable this feature for crates.io builds.
- As per source control conventions, no generated files are being pushed to the repository.

If there's anything I left out or need to consider additionally, please let me know. It's not too thoroughly tested except for the 2 cases that I've listed, but I hope this helps.