### PR TITLE
Fix lint non_fmt_panic. Fixes #505

### DIFF
--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -30,11 +30,11 @@ where
 {
     result.unwrap_or_else(|e| {
         panic!(
-            "grammar error\n\n".to_owned()
-                + &e.into_iter()
-                    .map(|error| format!("{}", error))
-                    .collect::<Vec<_>>()
-                    .join("\n\n")
+            "grammar error\n\n{}",
+            e.into_iter()
+                .map(|error| format!("{}", error))
+                .collect::<Vec<_>>()
+                .join("\n\n")
         )
     })
 }

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -169,11 +169,13 @@ macro_rules! parses_to {
                         ) => {
                             assert!(
                                 format!("{}", first_rule) == "EOI",
-                                format!("expected end of input, but found {:?}", rest)
+                                "expected end of input, but found {:?}",
+                                rest,
                             );
                             assert!(
                                 format!("{}", second_rule) == "EOI",
-                                format!("expected end of input, but found {:?}", rest)
+                                "expected end of input, but found {:?}",
+                                rest,
                             );
                         }
                         _ => panic!("expected end of input, but found {:?}", rest)


### PR DESCRIPTION
Includes the problem spotted by @01mf02 and two `assert!` calls.

This doesn't add anything to stop this being reintroduced - we could add an explicit deny for the lint maybe? Let me know if you want more than this.