### PR TITLE
Make pest_generator / pest_derive no_std compatible.

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,10 +15,14 @@ readme = "_README.md"
 name = "pest_derive"
 proc-macro = true
 
+[features]
+default = ["std"]
+std = ["pest/std", "pest_generator/std"]
+
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.1.0" }
-pest_generator = { path = "../generator", version = "2.1.0" }
+pest = { path = "../pest", version = "2.1.0", default-features = false }
+pest_generator = { path = "../generator", version = "2.1.0", default-features = false }
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/derive/tests/grammar.rs
+++ b/derive/tests/grammar.rs
@@ -7,6 +7,9 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 #![allow(unknown_lints, clippy)]
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+use alloc::{format, vec::Vec};
 
 #[macro_use]
 extern crate pest;

--- a/derive/tests/grammar_inline.rs
+++ b/derive/tests/grammar_inline.rs
@@ -4,6 +4,10 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+use alloc::{format, vec::Vec};
+
 #[macro_use]
 extern crate pest;
 #[macro_use]

--- a/derive/tests/lists.rs
+++ b/derive/tests/lists.rs
@@ -7,6 +7,10 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+use alloc::{format, vec::Vec};
+
 #[macro_use]
 extern crate pest;
 #[macro_use]

--- a/derive/tests/reporting.rs
+++ b/derive/tests/reporting.rs
@@ -7,6 +7,10 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+use alloc::vec;
+
 #[macro_use]
 extern crate pest;
 #[macro_use]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"
@@ -11,8 +11,12 @@ categories = ["parsing"]
 license = "MIT/Apache-2.0"
 readme = "_README.md"
 
+[features]
+default = ["std"]
+std = ["pest/std"]
+
 [dependencies]
-pest = { path = "../pest", version = "2.1.0" }
+pest = { path = "../pest", version = "2.1.0", default-features = false }
 pest_meta = { path = "../meta", version = "2.1.0" }
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/generator/src/macros.rs
+++ b/generator/src/macros.rs
@@ -21,24 +21,52 @@ macro_rules! insert_public_builtin {
     };
 }
 
+#[cfg(feature = "std")]
 macro_rules! generate_rule {
     ($name: ident, $pattern: expr) => {
         quote! {
             #[inline]
             #[allow(dead_code, non_snake_case, unused_variables)]
-            pub fn $name(state: Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<Box<::pest::ParserState<Rule>>> {
+            pub fn $name(state: ::std::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::std::boxed::Box<::pest::ParserState<Rule>>> {
                 $pattern
             }
         }
     }
 }
 
+#[cfg(not(feature = "std"))]
+macro_rules! generate_rule {
+    ($name: ident, $pattern: expr) => {
+        quote! {
+            #[inline]
+            #[allow(dead_code, non_snake_case, unused_variables)]
+            pub fn $name(state: ::alloc::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::alloc::boxed::Box<::pest::ParserState<Rule>>> {
+                $pattern
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
 macro_rules! generate_public_rule {
     ($name: ident, $pattern: expr) => {
         quote! {
             #[inline]
             #[allow(dead_code, non_snake_case, unused_variables)]
-            pub fn $name(state: Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<Box<::pest::ParserState<Rule>>> {
+            pub fn $name(state: ::std::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::std::boxed::Box<::pest::ParserState<Rule>>> {
+                $pattern
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+macro_rules! generate_public_rule {
+    ($name: ident, $pattern: expr) => {
+        quote! {
+            #[inline]
+            #[allow(dead_code, non_snake_case, unused_variables)]
+            pub fn $name(state: ::alloc::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::alloc::boxed::Box<::pest::ParserState<Rule>>> {
                 $pattern
             }
         }


### PR DESCRIPTION
This is the follow-up pull request to #498.
It adds "std" feature flags for both pest_generator and pest_derive.
Currently, the correct function of this can only be tested by running `cargo test --no-default-features` *in the `derive` directory*.
Running `cargo test --no-default-features` in the root directory unfortunately does not run the tests in no_std mode.