### PR TITLE
Add a function to retrieve the path from the Error struct

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -196,6 +196,35 @@ impl<R: RuleType> Error<R> {
         self
     }
 
+    /// Returns the path set using [`Error::with_path()`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pest::error::{Error, ErrorVariant};
+    /// # use pest::Position;
+    /// # #[allow(non_camel_case_types)]
+    /// # #[allow(dead_code)]
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// # enum Rule {
+    /// #     open_paren,
+    /// #     closed_paren
+    /// # }
+    /// # let input = "";
+    /// # let pos = Position::from_start(input);
+    /// # let error = Error::new_from_pos(
+    /// #     ErrorVariant::ParsingError {
+    /// #         positives: vec![Rule::open_paren],
+    /// #         negatives: vec![Rule::closed_paren]
+    /// #     },
+    /// #     pos);
+    /// let error = error.with_path("file.rs");
+    /// assert_eq!(Some("file.rs"), error.path());
+    /// ```
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
     /// Renames all `Rule`s if this is a [`ParsingError`]. It does nothing when called on a
     /// [`CustomError`].
     ///


### PR DESCRIPTION
Hi, I noticed there is currently no way to get the path set using `with_path` from `Error`. This short PR adds a function to get a reference to the currently set path.

My use case for this: I process a bunch of files and collect all parsing errors, then I'd like to filter and group them by the file that caused them. At the moment, I have the possibility to just get the location within the file, but not the path itself, because it is not public. I couldn't find a viable alternative to accomplish this.

Thank you for the great library!
Nico