### PR TITLE
Add input() method to get the input field of a Span

### DIFF
--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -32,6 +32,11 @@ pub struct Span<'i> {
 }
 
 impl<'i> Span<'i> {
+    /// Get the original input that this `Span` refers to without being indexed from `start` to
+    /// `end`.
+    pub fn input(&self) -> &'i str {
+        self.input
+    }
     /// Create a new `Span` without checking invariants. (Checked with `debug_assertions`.)
     ///
     /// # Safety


### PR DESCRIPTION
Hi! Thanks for making this great tool.

I'm writing a compiler, and I use `Span`s to keep track of error messages, warnings, source trees, etc. When it comes to rendering those messages, being able to get the reference to the original source directly from the `Span` is a really great feature -- otherwise I have to keep a mapping from `Span` to the original text and manage the lifetime differently.

If there is not a reason to exclude this method, could it be included in `Span`'s API?

Thanks,
Alex