### PR TITLE
Support left recursion syntax

### DIFF
--- a/pest/src/iterators/queueable_token.rs
+++ b/pest/src/iterators/queueable_token.rs
@@ -13,7 +13,7 @@
 //     increased speed when pushing to the queue
 //   * it finds its pair in O(1) time instead of O(N), since pair positions are known at parse time
 //     and can easily be stored instead of recomputed
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum QueueableToken<R> {
     Start {
         end_token_index: usize,

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -53,7 +53,7 @@ pub enum MatchDir {
 /// The complete state of a [`Parser`].
 ///
 /// [`Parser`]: trait.Parser.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParserState<'i, R: RuleType> {
     position: Position<'i>,
     queue: Vec<QueueableToken<R>>,

--- a/pest/src/stack.rs
+++ b/pest/src/stack.rs
@@ -13,7 +13,7 @@ use core::ops::{Index, Range};
 
 /// Implementation of a `Stack` which maintains an log of `StackOp`s in order to rewind the stack
 /// to a previous state.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Stack<T: Clone> {
     ops: Vec<StackOp<T>>,
     cache: Vec<T>,
@@ -110,7 +110,7 @@ impl<T: Clone> Index<Range<usize>> for Stack<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum StackOp<T> {
     Push(T),
     Pop(T),

--- a/pest/tests/leftrecursive.rs
+++ b/pest/tests/leftrecursive.rs
@@ -1,0 +1,215 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate pest;
+
+use pest::error::Error;
+use pest::iterators::Pairs;
+use pest::{state, ParseResult, Parser, ParserState};
+
+#[allow(dead_code, non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum Rule {
+    expression,
+    argument_list,
+    function_call,
+    callable_var,
+    variable,
+    symbol,
+}
+
+struct LeftRecursiveParser;
+
+/// Represent these indirect recursive syntax.
+///
+///     function_call = {
+///         callable_variable ~ argument_list
+///     }
+///
+///     callable_variable = {
+///         variable
+///         |  symbol+
+///         |  function_call
+///     }
+///
+impl Parser<Rule> for LeftRecursiveParser {
+    fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+        fn expression(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::expression, |s| {
+                s.sequence(|s| {
+                    variable(s)
+                    .or_else(|s| function_call(s))
+                })
+            })
+        }
+
+        fn argument_list(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::argument_list, |s| {
+                s.match_string("(")
+                .and_then(|s| {
+                    s.optional(|s| {
+                            expression(s)
+                            .and_then(|s| {
+                                s.optional(|s| s.repeat(|s| {
+                                    s.match_string(",")
+                                    .and_then(|s| expression(s))
+                                }))
+                            })
+                    })
+                })
+                .and_then(|s| s.match_string(")"))
+            })
+        }
+
+        fn callable_var(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::callable_var, |s| {
+                s.recursive(|s| function_call(s))
+                .or_else(|s| variable(s))
+                .or_else(|s| symbol(s))
+            })
+        }
+
+        fn function_call(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::function_call, |s| {
+                callable_var(s)
+                .and_then(|s| argument_list(s))
+            })
+        }
+
+        fn variable(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::variable, |s| {
+                s.sequence(|s| {
+                    s.match_string("$")
+                    .and_then(|s| symbol(s))
+                })
+            })
+        }
+
+        fn symbol(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::symbol, |s| s.repeat(|s| s.match_range('A'..'z')))
+        }
+
+        state(input, |state| match rule {
+            Rule::expression => expression(state),
+            // For troubleshoot at first, but then a test
+            Rule::argument_list => argument_list(state),
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[test]
+fn variable() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "$variable",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 9, [
+                variable(0, 9, [
+                    symbol(1, 9)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn argument_list() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "($abc)",
+        rule: Rule::argument_list,
+        tokens: [
+            argument_list(0, 6, [
+                expression(1, 5, [
+                    variable(1, 5, [
+                        symbol(2, 5)
+                    ])
+                ])
+            ])
+        ]
+    };
+
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "($abc,$cde)",
+        rule: Rule::argument_list,
+        tokens: [
+            argument_list(0, 11, [
+                expression(1, 5, [
+                    variable(1, 5, [
+                        symbol(2, 5)
+                    ]),
+                ]),
+                expression(6, 10, [
+                    variable(6, 10, [
+                        symbol(7, 10)
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn function_call() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "func($arga)",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 11, [
+                function_call(0, 11, [
+                    callable_var(0, 4, [
+                        symbol(0, 4),
+                    ]),
+                    argument_list(4, 11, [
+                        expression(5, 10, [
+                            variable(5, 10, [
+                                symbol(6, 10)
+                            ])
+                        ])
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn recursive_function_call() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "func()($arga)",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 13, [
+                function_call(0, 13, [
+                    callable_var(0, 6, [
+                        function_call(0, 6, [
+                            callable_var(0, 4, [
+                                symbol(0, 4),
+                            ]),
+                            argument_list(4, 6)
+                        ]),
+                    ]),
+                    argument_list(6, 13, [
+                        expression(7, 12, [
+                            variable(7, 12, [
+                                symbol(8, 12)
+                            ])
+                        ])
+                    ])
+                ])
+            ])
+        ]
+    };
+}

--- a/pest/tests/leftrecursive.rs
+++ b/pest/tests/leftrecursive.rs
@@ -36,7 +36,7 @@ struct LeftRecursiveParser;
 ///     callable_variable = {
 ///         variable
 ///         |  symbol+
-///         |  function_call
+///         |  *function_call
 ///     }
 ///
 impl Parser<Rule> for LeftRecursiveParser {

--- a/pest/tests/leftrecursive_simple.rs
+++ b/pest/tests/leftrecursive_simple.rs
@@ -33,7 +33,7 @@ struct LeftRecursiveParser;
 ///     function_call = {
 ///         (  variable
 ///         |  symbol+
-///         |  function_call
+///         |  *function_call
 ///         ) ~ argument_list
 ///     }
 ///

--- a/pest/tests/leftrecursive_simple.rs
+++ b/pest/tests/leftrecursive_simple.rs
@@ -1,0 +1,152 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate pest;
+
+use pest::error::Error;
+use pest::iterators::Pairs;
+use pest::{state, ParseResult, Parser, ParserState};
+
+#[allow(dead_code, non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum Rule {
+    expression,
+    argument_list,
+    function_call,
+    callable_var,
+    variable,
+    symbol,
+}
+
+struct LeftRecursiveParser;
+
+
+/// Represent this simple recursive syntax.
+///
+///     function_call = {
+///         (  variable
+///         |  symbol+
+///         |  function_call
+///         ) ~ argument_list
+///     }
+///
+impl Parser<Rule> for LeftRecursiveParser {
+    fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+        fn expression(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::expression, |s| {
+                s.sequence(|s| {
+                    variable(s)
+                    .or_else(|s| function_call(s))
+                })
+            })
+        }
+
+        fn argument_list(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::argument_list, |s| {
+                s.match_string("(")
+                .and_then(|s| s.match_string(")"))
+            })
+        }
+
+        fn function_call(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::function_call, |s| {
+                s.recursive(|s| function_call(s))
+                .or_else(|s| variable(s))
+                .or_else(|s| symbol(s))
+                .and_then(|s| argument_list(s))
+            })
+        }
+
+        fn variable(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::variable, |s| {
+                s.sequence(|s| {
+                    s.match_string("$")
+                    .and_then(|s| symbol(s))
+                })
+            })
+        }
+
+        fn symbol(state: Box<ParserState<Rule>>) -> ParseResult<Box<ParserState<Rule>>> {
+            state.rule(Rule::symbol, |s| s.repeat(|s| s.match_range('A'..'z')))
+        }
+
+        state(input, |state| match rule {
+            Rule::expression => expression(state),
+            // For troubleshoot at first, but then a test
+            Rule::argument_list => argument_list(state),
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[test]
+fn variable() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "$variable",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 9, [
+                variable(0, 9, [
+                    symbol(1, 9)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn argument_list() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "()",
+        rule: Rule::argument_list,
+        tokens: [
+            argument_list(0, 2)
+        ]
+    };
+}
+
+#[test]
+fn function_call() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "func()",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 6, [
+                function_call(0, 6, [
+                    symbol(0, 4),
+                    argument_list(4, 6)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn recursive_function_call() {
+    parses_to! {
+        parser: LeftRecursiveParser,
+        input: "func()()",
+        rule: Rule::expression,
+        tokens: [
+            expression(0, 8, [
+                function_call(0, 8, [
+                    function_call(0, 6, [
+                        symbol(0, 4),
+                        argument_list(4, 6)
+                    ]),
+                    argument_list(6, 8)
+                ])
+            ])
+        ]
+    };
+}


### PR DESCRIPTION
Add support to left recursion PEG by adding marker syntax.
Inspired by this awesome paper https://www.sciencedirect.com/science/article/pii/S0167642314000288.

# Checklist
- [x] Add single rule recursive processing.
- [x] Add single rule parser tests.
- [ ] Add multiple rule recursive processing.
- [ ] Add recursive marker syntax.
- [ ] Document the syntax.
