### PR TITLE
implement Copy for Position and Span

### DIFF
--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -17,7 +17,7 @@ use core::str;
 use span;
 
 /// A cursor position in a `&str` which provides useful methods to manually parse that string.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Position<'i> {
     input: &'i str,
     /// # Safety:

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -18,7 +18,7 @@ use position;
 ///
 /// [two `Position`s]: struct.Position.html#method.span
 /// [`Pair`]: ../iterators/struct.Pair.html#method.span
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Span<'i> {
     input: &'i str,
     /// # Safety


### PR DESCRIPTION
I would be very nice if these types were `Copy`.
If they are not `Copy` for a reason (which I assume has to do with future-proofing), then go ahead and close this.