### PR TITLE
Add yaml-peg to projects using Pest

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Digit:   2
 * [ZoKrates](https://github.com/ZoKrates/ZoKrates)
 * [Vector](https://github.com/timberio/vector)
 * [AutoCorrect](https://github.com/huacnlee/autocorrect)
+* [yaml-peg](https://github.com/aofdev/yaml-peg)
 
 ## Special thanks
 


### PR DESCRIPTION
Project: yaml-peg
Description: PEG parser for YAML written in Rust
Repo: https://github.com/aofdev/yaml-peg

**Grammar pest:** https://github.com/aofdev/yaml-peg/blob/main/src/parser/grammar/yaml.pest