### PR TITLE
Remove duplicated macro insert_public_builtin

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -99,7 +99,7 @@ fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
     let mut builtins = Vec::new();
 
     insert_builtin!(builtins, ANY, state.skip(1));
-    insert_public_builtin!(
+    insert_builtin!(
         builtins,
         EOI,
         state.rule(Rule::EOI, |state| state.end_of_input())

--- a/generator/src/macros.rs
+++ b/generator/src/macros.rs
@@ -14,13 +14,6 @@ macro_rules! insert_builtin {
     };
 }
 
-macro_rules! insert_public_builtin {
-    ($builtin: expr, $name: ident, $pattern: expr) => {
-        #[allow(clippy::vec_init_then_push)]
-        $builtin.push((stringify!($name), generate_public_rule!($name, $pattern)));
-    };
-}
-
 #[cfg(feature = "std")]
 macro_rules! generate_rule {
     ($name: ident, $pattern: expr) => {
@@ -36,32 +29,6 @@ macro_rules! generate_rule {
 
 #[cfg(not(feature = "std"))]
 macro_rules! generate_rule {
-    ($name: ident, $pattern: expr) => {
-        quote! {
-            #[inline]
-            #[allow(dead_code, non_snake_case, unused_variables)]
-            pub fn $name(state: ::alloc::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::alloc::boxed::Box<::pest::ParserState<Rule>>> {
-                $pattern
-            }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-macro_rules! generate_public_rule {
-    ($name: ident, $pattern: expr) => {
-        quote! {
-            #[inline]
-            #[allow(dead_code, non_snake_case, unused_variables)]
-            pub fn $name(state: ::std::boxed::Box<::pest::ParserState<Rule>>) -> ::pest::ParseResult<::std::boxed::Box<::pest::ParserState<Rule>>> {
-                $pattern
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "std"))]
-macro_rules! generate_public_rule {
     ($name: ident, $pattern: expr) => {
         quote! {
             #[inline]


### PR DESCRIPTION
Commit 9a0debfd26dd0317feef130e3e4791100eea39b5 added `pub` to `insert_builtin`, rendering `insert_public_builtin` obsolete.