### PR TITLE
Refactor/optimize validation

### DIFF
--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -16,6 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 [dependencies]
 maplit = "1.0"
 pest = { path = "../pest", version = "2.1.0" }
+lazy_static = "1.4.0"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 [dependencies]
 maplit = "1.0"
 pest = { path = "../pest", version = "2.1.0" }
-lazy_static = "1.4.0"
+once_cell = "1.8.0"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/meta/benches/validation.rs
+++ b/meta/benches/validation.rs
@@ -1,0 +1,43 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#![feature(test)]
+
+extern crate pest;
+extern crate pest_meta;
+extern crate test;
+
+use pest_meta::{
+    parser::{self, Rule},
+    validator,
+};
+use std::fs::File;
+use std::io::Read;
+use test::Bencher;
+
+#[bench]
+fn validate_pairs(b: &mut Bencher) {
+    let mut file = File::open("../meta/src/grammar.pest").unwrap();
+    let mut data = String::new();
+    file.read_to_string(&mut data).unwrap();
+
+    let pairs = parser::parse(Rule::grammar_rules, &data).unwrap();
+    b.iter(|| validator::validate_pairs(pairs.clone()));
+}
+
+#[bench]
+fn validate_ast(b: &mut Bencher) {
+    let mut file = File::open("../meta/src/grammar.pest").unwrap();
+    let mut data = String::new();
+    file.read_to_string(&mut data).unwrap();
+
+    let pairs = parser::parse(Rule::grammar_rules, &data).unwrap();
+    let rules = parser::consume_rules_with_spans(pairs).unwrap();
+    b.iter(|| validator::validate_ast(&rules));
+}

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -9,8 +9,7 @@
 
 #![allow(clippy::range_plus_one)]
 
-#[macro_use]
-extern crate lazy_static;
+extern crate once_cell;
 
 extern crate maplit;
 #[cfg(test)]

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -9,6 +9,9 @@
 
 #![allow(clippy::range_plus_one)]
 
+#[macro_use]
+extern crate lazy_static;
+
 extern crate maplit;
 #[cfg(test)]
 #[macro_use]
@@ -41,7 +44,8 @@ where
 
 #[doc(hidden)]
 pub static UNICODE_PROPERTY_NAMES: &[&str] = &[
-    /* BINARY */ "ALPHABETIC",
+    /* BINARY */
+    "ALPHABETIC",
     "BIDI_CONTROL",
     "CASE_IGNORABLE",
     "CASED",
@@ -93,7 +97,8 @@ pub static UNICODE_PROPERTY_NAMES: &[&str] = &[
     "WHITE_SPACE",
     "XID_CONTINUE",
     "XID_START",
-    /* CATEGORY */ "CASED_LETTER",
+    /* CATEGORY */
+    "CASED_LETTER",
     "CLOSE_PUNCTUATION",
     "CONNECTOR_PUNCTUATION",
     "CONTROL",

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -176,7 +176,7 @@ pub fn consume_rules(pairs: Pairs<Rule>) -> Result<Vec<AstRule>, Vec<Error<Rule>
     }
 }
 
-fn consume_rules_with_spans(pairs: Pairs<Rule>) -> Result<Vec<ParserRule>, Vec<Error<Rule>>> {
+pub fn consume_rules_with_spans(pairs: Pairs<Rule>) -> Result<Vec<ParserRule>, Vec<Error<Rule>>> {
     let climber = PrecClimber::new(vec![
         Operator::new(Rule::choice_operator, Assoc::Left),
         Operator::new(Rule::sequence_operator, Assoc::Left),

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -45,57 +45,57 @@ pub struct ParserNode<'i> {
 }
 
 impl<'i> ParserNode<'i> {
-    pub fn filter_map_top_down<F, T>(self, mut f: F) -> Vec<T>
+    pub fn filter_map_top_down<F, T>(&self, f: F) -> Vec<T>
     where
-        F: FnMut(ParserNode<'i>) -> Option<T>,
+        F: Fn(&ParserNode<'i>) -> Option<T>,
     {
-        pub fn filter_internal<'i, F, T>(node: ParserNode<'i>, f: &mut F, result: &mut Vec<T>)
+        pub fn filter_internal<'i, F, T>(node: &ParserNode<'i>, f: &F, result: &mut Vec<T>)
         where
-            F: FnMut(ParserNode<'i>) -> Option<T>,
+            F: Fn(&ParserNode<'i>) -> Option<T>,
         {
-            if let Some(value) = f(node.clone()) {
+            if let Some(value) = f(node) {
                 result.push(value);
             }
 
-            match node.expr {
+            match &node.expr {
                 // TODO: Use box syntax when it gets stabilized.
                 ParserExpr::PosPred(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::NegPred(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::Seq(lhs, rhs) => {
-                    filter_internal(*lhs, f, result);
-                    filter_internal(*rhs, f, result);
+                    filter_internal(&*lhs, f, result);
+                    filter_internal(&*rhs, f, result);
                 }
                 ParserExpr::Choice(lhs, rhs) => {
-                    filter_internal(*lhs, f, result);
-                    filter_internal(*rhs, f, result);
+                    filter_internal(&*lhs, f, result);
+                    filter_internal(&*rhs, f, result);
                 }
                 ParserExpr::Rep(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::RepOnce(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::RepExact(node, _) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::RepMin(node, _) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::RepMax(node, _) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::RepMinMax(node, ..) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::Opt(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 ParserExpr::Push(node) => {
-                    filter_internal(*node, f, result);
+                    filter_internal(&*node, f, result);
                 }
                 _ => (),
             }
@@ -103,7 +103,7 @@ impl<'i> ParserNode<'i> {
 
         let mut result = vec![];
 
-        filter_internal(self, &mut f, &mut result);
+        filter_internal(self, &f, &mut result);
 
         result
     }

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -187,10 +187,10 @@ fn is_non_progressing<'i>(
     rules: &HashMap<String, &ParserNode<'i>>,
     trace: &mut Vec<String>,
 ) -> bool {
-    match *expr {
-        ParserExpr::Str(ref string) => string.is_empty(),
-        ParserExpr::Ident(ref ident) => {
-            if ident == "soi" || ident == "eoi" {
+    match expr {
+        ParserExpr::Str(string) => string.is_empty(),
+        ParserExpr::Ident(ident) => {
+            if ident == "SOI" || ident == "EOI" {
                 return true;
             }
 
@@ -208,11 +208,11 @@ fn is_non_progressing<'i>(
         }
         ParserExpr::PosPred(_) => true,
         ParserExpr::NegPred(_) => true,
-        ParserExpr::Seq(ref lhs, ref rhs) => {
+        ParserExpr::Seq(lhs, rhs) => {
             is_non_progressing(&lhs.expr, rules, trace)
                 && is_non_progressing(&rhs.expr, rules, trace)
         }
-        ParserExpr::Choice(ref lhs, ref rhs) => {
+        ParserExpr::Choice(lhs, rhs) => {
             is_non_progressing(&lhs.expr, rules, trace)
                 || is_non_progressing(&rhs.expr, rules, trace)
         }
@@ -543,12 +543,12 @@ mod tests {
 
  --> 1:13
   |
-1 | COMMENT = { soi }
+1 | COMMENT = { SOI }
   |             ^-^
   |
   = COMMENT is non-progressing and will repeat infinitely")]
     fn non_progressing_comment() {
-        let input = "COMMENT = { soi }";
+        let input = "COMMENT = { SOI }";
         unwrap_or_report(consume_rules(
             PestParser::parse(Rule::grammar_rules, input).unwrap(),
         ));
@@ -607,12 +607,12 @@ mod tests {
 
  --> 1:7
   |
-1 | a = { (\"\" ~ &\"a\" ~ !\"a\" ~ (soi | eoi))* }
+1 | a = { (\"\" ~ &\"a\" ~ !\"a\" ~ (SOI | EOI))* }
   |       ^-------------------------------^
   |
   = expression inside repetition is non-progressing and will repeat infinitely")]
     fn non_progressing_repetition() {
-        let input = "a = { (\"\" ~ &\"a\" ~ !\"a\" ~ (soi | eoi))* }";
+        let input = "a = { (\"\" ~ &\"a\" ~ !\"a\" ~ (SOI | EOI))* }";
         unwrap_or_report(consume_rules(
             PestParser::parse(Rule::grammar_rules, input).unwrap(),
         ));

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -8,10 +8,7 @@
 // modified, or distributed except according to those terms.
 
 use once_cell::sync::Lazy;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Mutex,
-};
+use std::collections::{HashMap, HashSet};
 
 use pest::error::{Error, ErrorVariant, InputLocation};
 use pest::iterators::Pairs;
@@ -20,61 +17,54 @@ use pest::Span;
 use parser::{ParserExpr, ParserNode, ParserRule, Rule};
 use UNICODE_PROPERTY_NAMES;
 
-static RUST_KEYWORDS: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| {
-    Mutex::new(
-        [
-            "abstract", "alignof", "as", "become", "box", "break", "const", "continue", "crate",
-            "do", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
-            "let", "loop", "macro", "match", "mod", "move", "mut", "offsetof", "override", "priv",
-            "proc", "pure", "pub", "ref", "return", "Self", "self", "sizeof", "static", "struct",
-            "super", "trait", "true", "type", "typeof", "unsafe", "unsized", "use", "virtual",
-            "where", "while", "yield",
-        ]
-        .iter()
-        .cloned()
-        .collect(),
-    )
+static RUST_KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    [
+        "abstract", "alignof", "as", "become", "box", "break", "const", "continue", "crate", "do",
+        "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in", "let", "loop",
+        "macro", "match", "mod", "move", "mut", "offsetof", "override", "priv", "proc", "pure",
+        "pub", "ref", "return", "Self", "self", "sizeof", "static", "struct", "super", "trait",
+        "true", "type", "typeof", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+    ]
+    .iter()
+    .cloned()
+    .collect()
 });
 
-static PEST_KEYWORDS: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| {
-    Mutex::new(
-        [
-            "_", "ANY", "DROP", "EOI", "PEEK", "PEEK_ALL", "POP", "POP_ALL", "PUSH", "SOI",
-        ]
-        .iter()
-        .cloned()
-        .collect(),
-    )
+static PEST_KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    [
+        "_", "ANY", "DROP", "EOI", "PEEK", "PEEK_ALL", "POP", "POP_ALL", "PUSH", "SOI",
+    ]
+    .iter()
+    .cloned()
+    .collect()
 });
 
-static BUILTINS: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| {
-    Mutex::new(
-        [
-            "ANY",
-            "DROP",
-            "EOI",
-            "PEEK",
-            "PEEK_ALL",
-            "POP",
-            "POP_ALL",
-            "SOI",
-            "ASCII_DIGIT",
-            "ASCII_NONZERO_DIGIT",
-            "ASCII_BIN_DIGIT",
-            "ASCII_OCT_DIGIT",
-            "ASCII_HEX_DIGIT",
-            "ASCII_ALPHA_LOWER",
-            "ASCII_ALPHA_UPPER",
-            "ASCII_ALPHA",
-            "ASCII_ALPHANUMERIC",
-            "ASCII",
-            "NEWLINE",
-        ]
-        .iter()
-        .cloned()
-        .chain(UNICODE_PROPERTY_NAMES.iter().cloned())
-        .collect::<HashSet<&str>>(),
-    )
+static BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    [
+        "ANY",
+        "DROP",
+        "EOI",
+        "PEEK",
+        "PEEK_ALL",
+        "POP",
+        "POP_ALL",
+        "SOI",
+        "ASCII_DIGIT",
+        "ASCII_NONZERO_DIGIT",
+        "ASCII_BIN_DIGIT",
+        "ASCII_OCT_DIGIT",
+        "ASCII_HEX_DIGIT",
+        "ASCII_ALPHA_LOWER",
+        "ASCII_ALPHA_UPPER",
+        "ASCII_ALPHA",
+        "ASCII_ALPHANUMERIC",
+        "ASCII",
+        "NEWLINE",
+    ]
+    .iter()
+    .cloned()
+    .chain(UNICODE_PROPERTY_NAMES.iter().cloned())
+    .collect::<HashSet<&str>>()
 });
 
 #[allow(clippy::needless_pass_by_value)]
@@ -122,7 +112,7 @@ pub fn validate_rust_keywords<'i>(definitions: &Vec<Span<'i>>) -> Vec<Error<Rule
     for definition in definitions {
         let name = definition.as_str();
 
-        if RUST_KEYWORDS.lock().unwrap().contains(name) {
+        if RUST_KEYWORDS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("{} is a rust keyword", name),
@@ -141,7 +131,7 @@ pub fn validate_pest_keywords<'i>(definitions: &Vec<Span<'i>>) -> Vec<Error<Rule
     for definition in definitions {
         let name = definition.as_str();
 
-        if PEST_KEYWORDS.lock().unwrap().contains(name) {
+        if PEST_KEYWORDS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("{} is a pest keyword", name),
@@ -188,7 +178,7 @@ pub fn validate_undefined<'i>(
     for rule in called_rules {
         let name = rule.as_str();
 
-        if !definitions.contains(name) && !BUILTINS.lock().unwrap().contains(name) {
+        if !definitions.contains(name) && !BUILTINS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("rule {} is undefined", name),

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -16,96 +16,62 @@ use pest::Span;
 use parser::{ParserExpr, ParserNode, ParserRule, Rule};
 use UNICODE_PROPERTY_NAMES;
 
+lazy_static! {
+    static ref RUST_KEYWORDS: HashSet<&'static str> = {
+        let rust_keywords: HashSet<&'static str> = [
+            "abstract", "alignof", "as", "become", "box", "break", "const", "continue", "crate",
+            "do", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
+            "let", "loop", "macro", "match", "mod", "move", "mut", "offsetof", "override", "priv",
+            "proc", "pure", "pub", "ref", "return", "Self", "self", "sizeof", "static", "struct",
+            "super", "trait", "true", "type", "typeof", "unsafe", "unsized", "use", "virtual",
+            "where", "while", "yield",
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        rust_keywords
+    };
+    static ref PEST_KEYWORDS: HashSet<&'static str> = {
+        let pest_keywords: HashSet<&'static str> = [
+            "_", "ANY", "DROP", "EOI", "PEEK", "PEEK_ALL", "POP", "POP_ALL", "PUSH", "SOI",
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        pest_keywords
+    };
+    static ref BUILTINS: HashSet<&'static str> = {
+        let mut builtins: HashSet<&'static str> = [
+            "ANY",
+            "DROP",
+            "EOI",
+            "PEEK",
+            "PEEK_ALL",
+            "POP",
+            "POP_ALL",
+            "SOI",
+            "ASCII_DIGIT",
+            "ASCII_NONZERO_DIGIT",
+            "ASCII_BIN_DIGIT",
+            "ASCII_OCT_DIGIT",
+            "ASCII_HEX_DIGIT",
+            "ASCII_ALPHA_LOWER",
+            "ASCII_ALPHA_UPPER",
+            "ASCII_ALPHA",
+            "ASCII_ALPHANUMERIC",
+            "ASCII",
+            "NEWLINE",
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        builtins.extend(UNICODE_PROPERTY_NAMES);
+        builtins
+    };
+}
+
 #[allow(clippy::needless_pass_by_value)]
 pub fn validate_pairs(pairs: Pairs<Rule>) -> Result<Vec<&str>, Vec<Error<Rule>>> {
-    let mut rust_keywords = HashSet::new();
-    rust_keywords.insert("abstract");
-    rust_keywords.insert("alignof");
-    rust_keywords.insert("as");
-    rust_keywords.insert("become");
-    rust_keywords.insert("box");
-    rust_keywords.insert("break");
-    rust_keywords.insert("const");
-    rust_keywords.insert("continue");
-    rust_keywords.insert("crate");
-    rust_keywords.insert("do");
-    rust_keywords.insert("else");
-    rust_keywords.insert("enum");
-    rust_keywords.insert("extern");
-    rust_keywords.insert("false");
-    rust_keywords.insert("final");
-    rust_keywords.insert("fn");
-    rust_keywords.insert("for");
-    rust_keywords.insert("if");
-    rust_keywords.insert("impl");
-    rust_keywords.insert("in");
-    rust_keywords.insert("let");
-    rust_keywords.insert("loop");
-    rust_keywords.insert("macro");
-    rust_keywords.insert("match");
-    rust_keywords.insert("mod");
-    rust_keywords.insert("move");
-    rust_keywords.insert("mut");
-    rust_keywords.insert("offsetof");
-    rust_keywords.insert("override");
-    rust_keywords.insert("priv");
-    rust_keywords.insert("proc");
-    rust_keywords.insert("pure");
-    rust_keywords.insert("pub");
-    rust_keywords.insert("ref");
-    rust_keywords.insert("return");
-    rust_keywords.insert("Self");
-    rust_keywords.insert("self");
-    rust_keywords.insert("sizeof");
-    rust_keywords.insert("static");
-    rust_keywords.insert("struct");
-    rust_keywords.insert("super");
-    rust_keywords.insert("trait");
-    rust_keywords.insert("true");
-    rust_keywords.insert("type");
-    rust_keywords.insert("typeof");
-    rust_keywords.insert("unsafe");
-    rust_keywords.insert("unsized");
-    rust_keywords.insert("use");
-    rust_keywords.insert("virtual");
-    rust_keywords.insert("where");
-    rust_keywords.insert("while");
-    rust_keywords.insert("yield");
-
-    let mut pest_keywords = HashSet::new();
-    pest_keywords.insert("_");
-    pest_keywords.insert("ANY");
-    pest_keywords.insert("DROP");
-    pest_keywords.insert("EOI");
-    pest_keywords.insert("PEEK");
-    pest_keywords.insert("PEEK_ALL");
-    pest_keywords.insert("POP");
-    pest_keywords.insert("POP_ALL");
-    pest_keywords.insert("PUSH");
-    pest_keywords.insert("SOI");
-
-    let mut builtins = HashSet::new();
-    builtins.insert("ANY");
-    builtins.insert("DROP");
-    builtins.insert("EOI");
-    builtins.insert("PEEK");
-    builtins.insert("PEEK_ALL");
-    builtins.insert("POP");
-    builtins.insert("POP_ALL");
-    builtins.insert("SOI");
-    builtins.insert("ASCII_DIGIT");
-    builtins.insert("ASCII_NONZERO_DIGIT");
-    builtins.insert("ASCII_BIN_DIGIT");
-    builtins.insert("ASCII_OCT_DIGIT");
-    builtins.insert("ASCII_HEX_DIGIT");
-    builtins.insert("ASCII_ALPHA_LOWER");
-    builtins.insert("ASCII_ALPHA_UPPER");
-    builtins.insert("ASCII_ALPHA");
-    builtins.insert("ASCII_ALPHANUMERIC");
-    builtins.insert("ASCII");
-    builtins.insert("NEWLINE");
-    builtins.extend(UNICODE_PROPERTY_NAMES);
-
     let definitions: Vec<_> = pairs
         .clone()
         .filter(|pair| pair.as_rule() == Rule::grammar_rule)
@@ -125,10 +91,10 @@ pub fn validate_pairs(pairs: Pairs<Rule>) -> Result<Vec<&str>, Vec<Error<Rule>>>
 
     let mut errors = vec![];
 
-    errors.extend(validate_rust_keywords(&definitions, &rust_keywords));
-    errors.extend(validate_pest_keywords(&definitions, &pest_keywords));
+    errors.extend(validate_rust_keywords(&definitions));
+    errors.extend(validate_pest_keywords(&definitions));
     errors.extend(validate_already_defined(&definitions));
-    errors.extend(validate_undefined(&definitions, &called_rules, &builtins));
+    errors.extend(validate_undefined(&definitions, &called_rules));
 
     if !errors.is_empty() {
         return Err(errors);
@@ -143,16 +109,13 @@ pub fn validate_pairs(pairs: Pairs<Rule>) -> Result<Vec<&str>, Vec<Error<Rule>>>
 }
 
 #[allow(clippy::implicit_hasher, clippy::ptr_arg)]
-pub fn validate_rust_keywords<'i>(
-    definitions: &Vec<Span<'i>>,
-    rust_keywords: &HashSet<&str>,
-) -> Vec<Error<Rule>> {
+pub fn validate_rust_keywords<'i>(definitions: &Vec<Span<'i>>) -> Vec<Error<Rule>> {
     let mut errors = vec![];
 
     for definition in definitions {
         let name = definition.as_str();
 
-        if rust_keywords.contains(name) {
+        if RUST_KEYWORDS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("{} is a rust keyword", name),
@@ -165,17 +128,13 @@ pub fn validate_rust_keywords<'i>(
     errors
 }
 
-#[allow(clippy::implicit_hasher, clippy::ptr_arg)]
-pub fn validate_pest_keywords<'i>(
-    definitions: &Vec<Span<'i>>,
-    pest_keywords: &HashSet<&str>,
-) -> Vec<Error<Rule>> {
+pub fn validate_pest_keywords<'i>(definitions: &Vec<Span<'i>>) -> Vec<Error<Rule>> {
     let mut errors = vec![];
 
     for definition in definitions {
         let name = definition.as_str();
 
-        if pest_keywords.contains(name) {
+        if PEST_KEYWORDS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("{} is a pest keyword", name),
@@ -215,7 +174,6 @@ pub fn validate_already_defined(definitions: &Vec<Span>) -> Vec<Error<Rule>> {
 pub fn validate_undefined<'i>(
     definitions: &Vec<Span<'i>>,
     called_rules: &Vec<Span<'i>>,
-    builtins: &HashSet<&str>,
 ) -> Vec<Error<Rule>> {
     let mut errors = vec![];
     let definitions: HashSet<_> = definitions.iter().map(|span| span.as_str()).collect();
@@ -223,7 +181,7 @@ pub fn validate_undefined<'i>(
     for rule in called_rules {
         let name = rule.as_str();
 
-        if !definitions.contains(name) && !builtins.contains(name) {
+        if !definitions.contains(name) && !BUILTINS.contains(name) {
             errors.push(Error::new_from_span(
                 ErrorVariant::CustomError {
                     message: format!("rule {} is undefined", name),


### PR DESCRIPTION
(Built on top of #554 and overlaps some with #555, so once those are merged, I'll rebase to clean the history.)

I noticed that the functions called in `validate_pairs` each loop over the given `Pairs<Rule>` and build a vector of errors which are appended to a base vector. None of them rely on the full input at once (except `validate_undefined`), meaning that the internal loops can be rewritten to instead operate on a single Pair at a time, and the loop can be placed directly in `validate_pairs`.

`validate_undefined` is a little different, checking the referenced identifiers in rule expressions against the defined rule identifiers, but by inlining the referenced identifier gathering and then looping over it, we limit ourselves to two loops at most.

In doing all this, `validate_pairs` is now a little big, but I think that's okay given the limited scope of the function and the speed increases:
```
master (7422ae2549ff21ec714532aeee0f46e543e183f8):
test validate_pairs ... bench:      50,442 ns/iter (+/- 6,734)
test validate_pairs ... bench:      43,737 ns/iter (+/- 1,317)
test validate_pairs ... bench:      44,072 ns/iter (+/- 5,113)

refactor:
test validate_pairs ... bench:      30,243 ns/iter (+/- 1,063)
test validate_pairs ... bench:      32,939 ns/iter (+/- 3,940)
test validate_pairs ... bench:      31,779 ns/iter (+/- 3,547)
```

After finishing that work, my eyes fell to `validate_ast` where I saw that it "suffered" from the same repeated looping and vector building. It also had the issue of calling `to_hash_map` repeatedly (instead of defining the map once and passing it in), as well as relying on cloning to work around the borrow checker.

I didn't rearrange this as much, as each of the component functions is complex enough to warrant being left as distinct functions. Instead, I just removed the temporary vector building and extra looping, reducing error-gathering to one loop.

Once I verified that worked, I went through and cleaned up the unnecessary cloning, making a potentially breaking change to `filter_map_top_down` by making it take `self` by reference instead of by value. (This overlaps some with #555, which I will fix once that's merged too, lol. Really making a lot of work for myself here.)

With all that done, the results are quick striking (tho I suspect there's even further gains to be made):

```
master (7422ae2549ff21ec714532aeee0f46e543e183f8):
test validate_ast   ... bench:     796,490 ns/iter (+/- 46,665)
test validate_ast   ... bench:     800,321 ns/iter (+/- 80,054)
test validate_ast   ... bench:     800,774 ns/iter (+/- 49,783)

refactor:
test validate_ast   ... bench:     430,690 ns/iter (+/- 25,936)
test validate_ast   ... bench:     422,449 ns/iter (+/- 136,834)
test validate_ast   ... bench:     419,829 ns/iter (+/- 29,809)
```