### PR TITLE
removed unused maplit

### DIFF
--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -14,7 +14,6 @@ exclude = ["src/grammar.pest"]
 include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"]
 
 [dependencies]
-maplit = "1.0"
 pest = { path = "../pest", version = "2.1.0" }
 
 [badges]

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![allow(clippy::range_plus_one)]
 
-extern crate maplit;
 #[cfg(test)]
 #[macro_use]
 extern crate pest;


### PR DESCRIPTION
Hi,
I was trying to get my rust project to build on a M1 mac and maplit was breaking my build.
From what I can see maplit is not used, so I removed it.