### PR TITLE
fix: Remove deprecated Travis-CI links and deprecated `badges` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Book](https://img.shields.io/badge/book-WIP-4d76ae.svg)](https://pest-parser.github.io/book)
 [![Docs](https://docs.rs/pest/badge.svg)](https://docs.rs/pest)
 
-[![Build Status](https://travis-ci.org/pest-parser/pest.svg?branch=master)](https://travis-ci.org/pest-parser/pest)
+[![pest Continuous Integration](https://github.com/pest-parser/pest/actions/workflows/ci.yml/badge.svg)](https://github.com/pest-parser/pest/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pest-parser/pest/branch/master/graph/badge.svg)](https://codecov.io/gh/pest-parser/pest)
 [![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=pest-parser)](https://app.fuzzit.dev/orgs/pest-parser/dashboard)
 [![Crates.io](https://img.shields.io/crates/d/pest.svg)](https://crates.io/crates/pest)

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -12,8 +12,3 @@ license = "MIT/Apache-2.0"
 [dependencies]
 pest_generator = "2.1.1" # Use the crates-io version, which (should be) known-good
 quote = "1.0"
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -23,8 +23,3 @@ std = ["pest/std", "pest_generator/std"]
 # for tests, included transitively anyway
 pest = { path = "../pest", version = "2.1.0", default-features = false }
 pest_generator = { path = "../generator", version = "2.1.0", default-features = false }
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -21,8 +21,3 @@ pest_meta = { path = "../meta", version = "2.1.0" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -14,8 +14,3 @@ readme = "_README.md"
 [dependencies]
 pest = { path = "../pest", version = "2.1.0" }
 pest_derive = { path = "../derive", version = "2.1.0" }
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -16,10 +16,5 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 [dependencies]
 pest = { path = "../pest", version = "2.1.0" }
 
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }
-
 [build-dependencies]
 sha-1 = { version = "0.10", default-features = false }

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -24,8 +24,3 @@ const_prec_climber = []
 ucd-trie = { version = "0.1.1", default-features = false }
 serde = { version = "1.0.89", optional = true }
 serde_json = { version = "1.0.39", optional = true}
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -14,8 +14,3 @@ readme = "_README.md"
 [dependencies]
 pest = { path = "../pest", version = "2.1.0" }
 pest_meta = { path = "../meta", version = "2.1.0" }
-
-[badges]
-codecov = { repository = "pest-parser/pest" }
-maintenance = { status = "actively-developed" }
-travis-ci = { repository = "pest-parser/pest" }


### PR DESCRIPTION
- Remove deprecated Travis-CI status badge from main README.md and use current GitHub action based CI badge to show current build/CI status on default branch
- Remove links under Cargo.toml `badge` section since this functionality has been deprecated and removed - [Reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section)