### PR TITLE
chore: update dependencies by unpinning from patch version and rely on minor version

### DIFF
--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 license = "MIT/Apache-2.0"
 
 [dependencies]
-pest_generator = "2.1.1" # Use the crates-io version, which (should be) known-good
+pest_generator = "2.1" # Use the crates-io version, which (should be) known-good
 quote = "1.0"

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -11,4 +11,5 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 pest_generator = "2.1" # Use the crates-io version, which (should be) known-good
+proc-macro2 = "1.0"
 quote = "1.0"

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 extern crate quote;
 extern crate pest_generator;
+extern crate proc_macro2;
 
+use proc_macro2::TokenStream;
 use pest_generator::derive_parser;
 use std::{fs::File, io::prelude::*, path::Path};
 
@@ -17,7 +19,7 @@ fn main() {
 
     let derived = {
         let path = pest.to_string_lossy();
-        let pest = quote! {
+        let pest: TokenStream = quote! {
             #[grammar = #path]
             pub struct PestParser;
         };

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -23,3 +23,4 @@ std = ["pest/std", "pest_generator/std"]
 # for tests, included transitively anyway
 pest = { path = "../pest", version = "2.1.0", default-features = false }
 pest_generator = { path = "../generator", version = "2.1.0", default-features = false }
+proc-macro2 = "1.0"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -291,11 +291,11 @@
 
 #![doc(html_root_url = "https://docs.rs/pest_derive")]
 extern crate pest_generator;
-extern crate proc_macro;
+extern crate proc_macro2;
 
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 
 #[proc_macro_derive(Parser, attributes(grammar, grammar_inline))]
 pub fn derive_parser(input: TokenStream) -> TokenStream {
-    pest_generator::derive_parser(input.into(), true).into()
+    pest_generator::derive_parser(input.into(), true)
 }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -13,7 +13,6 @@
 extern crate pest;
 extern crate pest_meta;
 
-extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -21,6 +21,6 @@ pretty-print = ["serde", "serde_json"]
 const_prec_climber = []
 
 [dependencies]
-ucd-trie = { version = "0.1.1", default-features = false }
-serde = { version = "1.0.89", optional = true }
-serde_json = { version = "1.0.39", optional = true}
+ucd-trie = { version = "0.1", default-features = false }
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true}


### PR DESCRIPTION
## Changes
- Remove patch version constraint on external dependencies

## Motivation
- This allows for the latest patch version to be pulled by users which should be quite stable since the minor version is not changing
- https://github.com/dtolnay/quote/issues/204