### PR TITLE
fix: Limit error messages new line visualization (fixes #362)

### DIFF
--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -318,6 +318,14 @@ impl<'i> Position<'i> {
         false
     }
 
+    /// Matches the char at the `Position` against a specified character and returns `true` if a match
+    /// was made. If no match was made, returns `false`.
+    /// `pos` will not be updated in either case.
+    #[inline]
+    pub(crate) fn match_char(&self, c: char) -> bool {
+        matches!(self.input[self.pos..].chars().next(), Some(cc) if c == cc)
+    }
+
     /// Matches the char at the `Position` against a filter function and returns `true` if a match
     /// was made. If no match was made, returns `false` and `pos` will not be updated.
     #[inline]


### PR DESCRIPTION
`new_from_pos` and `new_from_span` only visualize newline
characters if positions point to the newline characters.