### PR TITLE
Migrate to `thiserror`

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -25,3 +25,4 @@ const_prec_climber = []
 ucd-trie = { version = "0.1.1", default-features = false }
 serde = { version = "1.0.89", optional = true }
 serde_json = { version = "1.0.39", optional = true}
+thiserror = "1.0.31"

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -15,7 +15,7 @@ readme = "_README.md"
 [features]
 default = ["std"]
 # Implements `std::error::Error` for the `Error` type
-std = ["ucd-trie/std"]
+std = ["ucd-trie/std", "thiserror"]
 # Enables the `to_json` function for `Pair` and `Pairs`
 pretty-print = ["serde", "serde_json"]
 # Enable const fn constructor for `PrecClimber` (requires nightly)
@@ -25,4 +25,4 @@ const_prec_climber = []
 ucd-trie = { version = "0.1.1", default-features = false }
 serde = { version = "1.0.89", optional = true }
 serde_json = { version = "1.0.39", optional = true}
-thiserror = "1.0.31"
+thiserror = { version = "1.0.31", optional = true }

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -25,7 +25,9 @@ use crate::RuleType;
 
 /// Parse-related error type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Error<R> {
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(feature = "std", error("An error was encountered while parsing:\n{}", self.format()))]
+pub struct Error<R: RuleType> {
     /// Variant of the error
     pub variant: ErrorVariant<R>,
     /// Location within the input string
@@ -39,8 +41,10 @@ pub struct Error<R> {
 
 /// Different kinds of parsing errors.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum ErrorVariant<R> {
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+pub enum ErrorVariant<R: RuleType> {
     /// Generated parsing error with expected and unexpected `Rule`s
+    #[cfg_attr(feature = "std", error("{}", self.message()))]
     ParsingError {
         /// Positive attempts
         positives: Vec<R>,
@@ -48,6 +52,7 @@ pub enum ErrorVariant<R> {
         negatives: Vec<R>,
     },
     /// Custom error with a message
+    #[cfg_attr(feature = "std", error("{}", self.message()))]
     CustomError {
         /// Short explanation
         message: String,
@@ -510,22 +515,6 @@ impl<R: RuleType> ErrorVariant<R> {
                 format!("{:?}", r)
             })),
             ErrorVariant::CustomError { ref message } => Cow::Borrowed(message),
-        }
-    }
-}
-
-impl<R: RuleType> fmt::Display for Error<R> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.format())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<'i, R: RuleType> std::error::Error for Error<R> {
-    fn description(&self) -> &str {
-        match self.variant {
-            ErrorVariant::ParsingError { .. } => "parsing error",
-            ErrorVariant::CustomError { ref message } => message,
         }
     }
 }

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -25,7 +25,7 @@ use crate::RuleType;
 /// Parse-related error type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
-#[cfg_attr(feature = "std", error("An error was encountered while parsing:\n{}", self.format()))]
+#[cfg_attr(feature = "std", error("{}", self.format()))]
 pub struct Error<R: RuleType> {
     /// Variant of the error
     pub variant: ErrorVariant<R>,

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -43,7 +43,7 @@ pub struct Error<R: RuleType> {
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum ErrorVariant<R: RuleType> {
     /// Generated parsing error with expected and unexpected `Rule`s
-    #[cfg_attr(feature = "std", error("{}", self.message()))]
+    #[cfg_attr(feature = "std", error("parsing error: {}", self.message()))]
     ParsingError {
         /// Positive attempts
         positives: Vec<R>,

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -16,7 +16,6 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::cmp;
-use core::fmt;
 use core::mem;
 
 use crate::position::Position;


### PR DESCRIPTION
In an effort to update this crate, I have migrated the `error` module of `pest` to `thiserror`. This removes some boilerplate impls, and makes its errors compatible with some other error reporting tools.