### PR TITLE
Implementation of modules/use statements

### DIFF
--- a/derive/tests/grammar.pest
+++ b/derive/tests/grammar.pest
@@ -84,3 +84,5 @@ COMMENT = _{ "$"+ }
 
 	WHITESPACE = _{ "hi" }
 */
+
+mod x { y = { "y" } }

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -473,6 +473,9 @@ fn generate_expr(expr: OptimizedExpr) -> TokenStream {
                 state.stack_push(|state| #expr)
             }
         }
+        OptimizedExpr::Module(name, exprs) => {
+            quote! {}
+        }
         OptimizedExpr::RestoreOnErr(expr) => {
             let expr = generate_expr(*expr);
 
@@ -604,6 +607,9 @@ fn generate_expr_atomic(expr: OptimizedExpr) -> TokenStream {
             quote! {
                 state.stack_push(|state| #expr)
             }
+        }
+        OptimizedExpr::Module(name, exprs) => {
+            quote! {}
         }
         OptimizedExpr::RestoreOnErr(expr) => {
             let expr = generate_expr_atomic(*expr);

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -91,8 +91,10 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
         ),
     };
 
-    let defaults = unwrap_or_report(validator::validate_pairs(pairs.clone()));
+    let defaults = validator::validate_pairs(pairs.clone()).unwrap();
+
     let ast = unwrap_or_report(parser::consume_rules(pairs));
+    dbg!(&ast);
     let optimized = optimizer::optimize(ast);
 
     generator::generate(name, &generics, path, optimized, defaults, include_grammar)

--- a/meta/src/grammar.pest
+++ b/meta/src/grammar.pest
@@ -7,12 +7,14 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-grammar_rules = _{ SOI ~ grammar_rule+ ~ EOI }
+grammar_rules = _{ SOI ~ (grammar_rule | module)+ ~ EOI }
 
 grammar_rule = {
     identifier ~ assignment_operator ~ modifier? ~
     opening_brace ~ expression ~ closing_brace
 }
+
+module = { "mod" ~ identifier ~ opening_brace ~ grammar_rule+ ~ closing_brace }
 
 assignment_operator = { "=" }
 opening_brace       = { "{" }

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -65,6 +65,10 @@ fn rule_to_optimized_rule(rule: Rule) -> OptimizedRule {
             Expr::Rep(expr) => OptimizedExpr::Rep(Box::new(to_optimized(*expr))),
             Expr::Skip(strings) => OptimizedExpr::Skip(strings),
             Expr::Push(expr) => OptimizedExpr::Push(Box::new(to_optimized(*expr))),
+            Expr::Module(name, exprs) => OptimizedExpr::Module(
+                name,
+                exprs.iter().map(|x| to_optimized(x.to_owned())).collect(),
+            ),
             Expr::RepOnce(_)
             | Expr::RepExact(..)
             | Expr::RepMin(..)
@@ -110,6 +114,7 @@ pub enum OptimizedExpr {
     Skip(Vec<String>),
     Push(Box<OptimizedExpr>),
     RestoreOnErr(Box<OptimizedExpr>),
+    Module(String, Vec<OptimizedExpr>),
 }
 
 impl OptimizedExpr {

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -109,7 +109,9 @@ pub fn validate_pairs(pairs: Pairs<Rule>) -> Result<Vec<&str>, Vec<Error<Rule>>>
     let definitions: Vec<_> = pairs
         .clone()
         .filter(|pair| pair.as_rule() == Rule::grammar_rule)
-        .map(|pair| pair.into_inner().next().unwrap().as_span())
+        .map(|pair| pair.into_inner().next().unwrap())
+        .filter(|pair| pair.as_rule() != Rule::module)
+        .map(|pair| pair.as_span())
         .collect();
     let called_rules: Vec<_> = pairs
         .clone()

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -144,7 +144,7 @@ impl Vm {
     fn parse_expr<'a, 'i>(
         &'a self,
         expr: &'a OptimizedExpr,
-        state: Box<ParserState<'i, &'a str>>,
+        mut state: Box<ParserState<'i, &'a str>>,
     ) -> ParseResult<Box<ParserState<'i, &'a str>>> {
         match *expr {
             OptimizedExpr::Str(ref string) => state.match_string(string),
@@ -193,6 +193,13 @@ impl Vm {
                     .map(|state| state.as_str())
                     .collect::<Vec<&str>>(),
             ),
+            OptimizedExpr::Module(_, ref exprs) => {
+                for expr in exprs {
+                    state = self.parse_expr(expr, state)?;
+                }
+
+                Ok(state)
+            }
             OptimizedExpr::RestoreOnErr(ref expr) => {
                 state.restore_on_err(|state| self.parse_expr(expr, state))
             }


### PR DESCRIPTION
This is an initial draft implementation for modules, that I picked up about a week ago.  Hopefully, this will lead to use statements and eventually, a standard library.

## Syntax

A module can be defined similarly to Rust:

```
mod x {
  y = ...
}
```

Any element in a module should be referenced with the module prefix:

```
a = { x::y }
```

Unless imported into scope.

```
use x::y
a = { y }
```

Additionally, pest searches a default location for its standard library, which is added as the `std` module.

```
use std::...
```