### PR TITLE
Conditionally implement `miette::Diagnostic` for `pest::error:Error`

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -21,9 +21,15 @@ std = ["ucd-trie/std", "thiserror"]
 pretty-print = ["serde", "serde_json"]
 # Enable const fn constructor for `PrecClimber`
 const_prec_climber = []
+# Enables error compatibility with miette
+miette = ["dep:miette", "std"]
 
 [dependencies]
 ucd-trie = { version = "0.1.1", default-features = false }
 serde = { version = "1.0.89", optional = true }
 serde_json = { version = "1.0.39", optional = true}
 thiserror = { version = "1.0.31", optional = true }
+miette = { version = "5.1.1", optional = true }
+
+[dev-dependencies]
+miette = { version = "5.1.1", features = ["fancy"] }

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -21,8 +21,6 @@ std = ["ucd-trie/std", "thiserror"]
 pretty-print = ["serde", "serde_json"]
 # Enable const fn constructor for `PrecClimber`
 const_prec_climber = []
-# Enables error compatibility with miette
-miette = ["dep:miette", "std"]
 
 [dependencies]
 ucd-trie = { version = "0.1.1", default-features = false }

--- a/pest/examples/parens.rs
+++ b/pest/examples/parens.rs
@@ -2,9 +2,6 @@ extern crate pest;
 
 use std::io::{self, Write};
 
-#[cfg(feature = "miette")]
-use miette::IntoDiagnostic;
-
 use pest::error::Error;
 use pest::iterators::Pairs;
 use pest::{state, ParseResult, Parser, ParserState};
@@ -78,6 +75,11 @@ fn main() {
 
         match parsed {
             Ok(pairs) => println!("{:?}", expr(pairs)),
+            // To print pest errors, use Display formatting.
+            #[cfg(not(feature = "miette"))]
+            Err(e) => eprintln!("\n{}", e),
+            // To print miette errors, use Debug formatting.
+            #[cfg(feature = "miette")]
             Err(e) => eprintln!("\n{:?}", e),
         };
     }

--- a/pest/examples/parens.rs
+++ b/pest/examples/parens.rs
@@ -2,6 +2,9 @@ extern crate pest;
 
 use std::io::{self, Write};
 
+#[cfg(feature = "miette")]
+use miette::IntoDiagnostic;
+
 use pest::error::Error;
 use pest::iterators::Pairs;
 use pest::{state, ParseResult, Parser, ParserState};
@@ -57,6 +60,7 @@ fn expr(pairs: Pairs<Rule>) -> Vec<Paren> {
         .collect()
 }
 
+#[cfg(not(feature = "miette"))]
 fn main() {
     loop {
         let mut line = String::new();
@@ -71,5 +75,20 @@ fn main() {
             Ok(pairs) => println!("{:?}", expr(pairs)),
             Err(e) => println!("\n{}", e),
         };
+    }
+}
+
+#[cfg(feature = "miette")]
+fn main() -> miette::Result<()> {
+    loop {
+        let mut line = String::new();
+
+        print!("> ");
+        io::stdout().flush().into_diagnostic()?;
+
+        io::stdin().read_line(&mut line).into_diagnostic()?;
+        line.pop();
+
+        ParenParser::parse(Rule::expr, &line)?;
     }
 }

--- a/pest/examples/parens.rs
+++ b/pest/examples/parens.rs
@@ -60,7 +60,6 @@ fn expr(pairs: Pairs<Rule>) -> Vec<Paren> {
         .collect()
 }
 
-#[cfg(not(feature = "miette"))]
 fn main() {
     loop {
         let mut line = String::new();
@@ -71,24 +70,15 @@ fn main() {
         io::stdin().read_line(&mut line).unwrap();
         line.pop();
 
-        match ParenParser::parse(Rule::expr, &line) {
+        let parsed = ParenParser::parse(Rule::expr, &line);
+        #[cfg(feature = "miette")]
+        let parsed = parsed
+            .map_err(Error::into_miette)
+            .map_err(miette::Report::from);
+
+        match parsed {
             Ok(pairs) => println!("{:?}", expr(pairs)),
-            Err(e) => println!("\n{}", e),
+            Err(e) => eprintln!("\n{:?}", e),
         };
-    }
-}
-
-#[cfg(feature = "miette")]
-fn main() -> miette::Result<()> {
-    loop {
-        let mut line = String::new();
-
-        print!("> ");
-        io::stdout().flush().into_diagnostic()?;
-
-        io::stdin().read_line(&mut line).into_diagnostic()?;
-        line.pop();
-
-        ParenParser::parse(Rule::expr, &line)?;
     }
 }

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -9,6 +9,9 @@
 
 //! Types for different kinds of parsing failures.
 
+#[cfg(feature = "miette")]
+use std::boxed::Box;
+
 use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::format;
@@ -16,6 +19,7 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::cmp;
+use core::fmt;
 use core::mem;
 
 use crate::position::Position;
@@ -25,7 +29,8 @@ use crate::RuleType;
 /// Parse-related error type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
-#[cfg_attr(feature = "std", error("{}", self.format()))]
+#[cfg_attr(all(feature = "std", not(feature = "miette")), error("{}", self.format()))]
+#[cfg_attr(all(feature = "std", feature = "miette"), error("Failed to parse at {}", self.line_col))]
 pub struct Error<R: RuleType> {
     /// Variant of the error
     pub variant: ErrorVariant<R>,
@@ -36,6 +41,30 @@ pub struct Error<R: RuleType> {
     path: Option<String>,
     line: String,
     continued_line: Option<String>,
+}
+
+#[cfg(feature = "miette")]
+impl<R: RuleType> miette::Diagnostic for Error<R> {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.line)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan>>> {
+        let message = self.variant.message().to_string();
+
+        let (offset, length) = match self.location {
+            InputLocation::Pos(x) => (x, 0),
+            InputLocation::Span((x, y)) => (x, y),
+        };
+
+        let span = miette::LabeledSpan::new(Some(message), offset, length);
+
+        Some(Box::new(std::iter::once(span)))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        Some(Box::new(self.variant.message()))
+    }
 }
 
 /// Different kinds of parsing errors.
@@ -74,6 +103,15 @@ pub enum LineColLocation {
     Pos((usize, usize)),
     /// Line/column pairs if `Error` was created by `Error::new_from_span`
     Span((usize, usize), (usize, usize)),
+}
+
+impl fmt::Display for LineColLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pos((l, c)) => write!(f, "({}, {})", l, c),
+            Self::Span((ls, cs), (le, ce)) => write!(f, "({}, {}) to ({}, {})", ls, cs, le, ce),
+        }
+    }
 }
 
 impl<R: RuleType> Error<R> {
@@ -411,7 +449,7 @@ impl<R: RuleType> Error<R> {
         }
     }
 
-    pub(crate) fn format(&self) -> String {
+    pub fn format(&self) -> String {
         let spacing = self.spacing();
         let path = self
             .path


### PR DESCRIPTION
Hides an implementation of [miette](lib.rs/miette)'s `Diagnostic` type under the `miette` feature flag. Also adds example usage to the `parens` example.

The only issue I have with this is that the Display of `error::Error` changes based on this flag. Since miette displays the error *and then* the diagnostic, the error would be printed twice: once in pest's form, and once in miette's form. Hnce, `error.rs:32-33` changes the display value of `Error` if the miette feature is enabled. In my opinion, it's not a clean solution, so I'd love to hear feedback.

Note: public API change: `pest::error::Error::formt(&self) -> String` is publicized, so users on the miette feature flag can still read Pest's errors if needed.

Closes #582 