### PR TITLE
ci: fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.56.1
+        uses: dtolnay/rust-toolchain@1.61.0
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing


### PR DESCRIPTION
building with `--all-features` fails on 1.56 :(