### PR TITLE
fix: undo https://github.com/pest-parser/pest/pull/522

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,49 @@ jobs:
       - name: Bootstraping Grammars - Executing
         run: cargo run --package pest_bootstrap
       # it should figure out the right order: https://github.com/katyo/publish-crates#features
-      - name: Publish crates
+      - name: Publish pest
         uses: katyo/publish-crates@v1
         with:
+          path: './pest'
+          args: --allow-dirty --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: update
+        run: cargo update
+      - name: Publish pest_meta
+        uses: katyo/publish-crates@v1
+        with:
+          path: './meta'
+          args: --allow-dirty --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: update
+        run: cargo update
+      - name: Publish pest_vm
+        uses: katyo/publish-crates@v1
+        with:
+          path: './vm'
+          args: --allow-dirty --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: update
+        run: cargo update
+      - name: Publish pest_generator
+        uses: katyo/publish-crates@v1
+        with:
+          path: './generator'
+          args: --allow-dirty --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: update
+        run: cargo update
+      - name: Publish pest_derive
+        uses: katyo/publish-crates@v1
+        with:
+          path: './derive'
+          args: --allow-dirty --all-features
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: update
+        run: cargo update
+      - name: Publish pest_grammars
+        uses: katyo/publish-crates@v1
+        with:
+          path: './grammars'
           args: --allow-dirty --all-features
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -23,5 +23,5 @@ std = ["pest/std", "pest_generator/std"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.2.0", default-features = false }
-pest_generator = { path = "../generator", version = "2.2.0", default-features = false }
+pest = { path = "../pest", version = "2.2.1", default-features = false }
+pest_generator = { path = "../generator", version = "2.2.1", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -18,8 +18,8 @@ default = ["std"]
 std = ["pest/std"]
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.0", default-features = false }
-pest_meta = { path = "../meta", version = "2.2.0" }
+pest = { path = "../pest", version = "2.2.1", default-features = false }
+pest_meta = { path = "../meta", version = "2.2.1" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn::{self, Generics, Ident};
@@ -18,7 +20,7 @@ use pest_meta::UNICODE_PROPERTY_NAMES;
 pub fn generate(
     name: Ident,
     generics: &Generics,
-    path: Option<String>,
+    path: Option<PathBuf>,
     rules: Vec<OptimizedRule>,
     defaults: Vec<&str>,
     include_grammar: bool,
@@ -28,7 +30,7 @@ pub fn generate(
     let builtins = generate_builtin_rules();
     let include_fix = if include_grammar {
         match path {
-            Some(ref path) => generate_include(&name, path),
+            Some(ref path) => generate_include(&name, path.to_str().expect("non-Unicode path")),
             None => quote!(),
         }
     } else {
@@ -168,9 +170,14 @@ fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
 // Needed because Cargo doesn't watch for changes in grammars.
 fn generate_include(name: &Ident, path: &str) -> TokenStream {
     let const_name = Ident::new(&format!("_PEST_GRAMMAR_{}", name), Span::call_site());
+    // Need to make this relative to the current directory since the path to the file
+    // is derived from the CARGO_MANIFEST_DIR environment variable
+    let mut current_dir = std::env::current_dir().expect("Unable to get current directory");
+    current_dir.push(path);
+    let relative_path = current_dir.to_str().expect("path contains invalid unicode");
     quote! {
         #[allow(non_upper_case_globals)]
-        const #const_name: &'static str = include_str!(#path);
+        const #const_name: &'static str = include_str!(#relative_path);
     }
 }
 
@@ -961,11 +968,14 @@ mod tests {
         let defaults = vec!["ANY"];
         let result = result_type();
         let box_ty = box_type();
+        let mut current_dir = std::env::current_dir().expect("Unable to get current directory");
+        current_dir.push("test.pest");
+        let test_path = current_dir.to_str().expect("path contains invalid unicode");
         assert_eq!(
-            generate(name, &generics, Some(String::from("test.pest")), rules, defaults, true).to_string(),
+            generate(name, &generics, Some(PathBuf::from("test.pest")), rules, defaults, true).to_string(),
             quote! {
                 #[allow(non_upper_case_globals)]
-                const _PEST_GRAMMAR_MyParser: &'static str = include_str!("test.pest");
+                const _PEST_GRAMMAR_MyParser: &'static str = include_str!(#test_path);
 
                 #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
                 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -39,19 +39,19 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
     let (name, generics, content) = parse_derive(ast);
 
     let (data, path) = match content {
-        GrammarSource::File(path) => {
+        GrammarSource::File(ref path) => {
             let root = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
-            let full_path = Path::new(&root).join("src/").join(&path);
-            let file_name = match full_path.file_name() {
+            let path = Path::new(&root).join("src/").join(&path);
+            let file_name = match path.file_name() {
                 Some(file_name) => file_name,
                 None => panic!("grammar attribute should point to a file"),
             };
 
-            let data = match read_file(&full_path) {
+            let data = match read_file(&path) {
                 Ok(data) => data,
                 Err(error) => panic!("error opening {:?}: {}", file_name, error),
             };
-            (data, Some(path))
+            (data, Some(path.clone()))
         }
         GrammarSource::Inline(content) => (content, None),
     };

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.0" }
-pest_derive = { path = "../derive", version = "2.2.0" }
+pest = { path = "../pest", version = "2.2.1" }
+pest_derive = { path = "../derive", version = "2.2.1" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.0" }
+pest = { path = "../pest", version = "2.2.1" }
 once_cell = "1.8.0"
 
 [build-dependencies]

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -14,5 +14,5 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.0" }
-pest_meta = { path = "../meta", version = "2.2.0" }
+pest = { path = "../pest", version = "2.2.1" }
+pest_meta = { path = "../meta", version = "2.2.1" }


### PR DESCRIPTION
closes https://github.com/pest-parser/pest/issues/672

+ bumped version numbers and split up the release flow as a workaround for a bug in katyo/publish-crates GH action