### PR TITLE
Implement `Span::get`

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -14,7 +14,7 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [features]
-default = ["std"]
+# default = ["std"]
 # Implements `std::error::Error` for the `Error` type
 std = ["ucd-trie/std", "thiserror"]
 # Enables the `to_json` function for `Pair` and `Pairs`

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -14,7 +14,7 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [features]
-# default = ["std"]
+default = ["std"]
 # Implements `std::error::Error` for the `Error` type
 std = ["ucd-trie/std", "thiserror"]
 # Enables the `to_json` function for `Pair` and `Pairs`

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -86,14 +86,11 @@ impl<'i> Span<'i> {
             std::ops::Bound::Unbounded => self.as_str().len(),
         };
 
-        match self.as_str().get(start..end) {
-            Some(_) => Some(Span {
-                input: self.input,
-                start: self.start + start,
-                end: self.start + end,
-            }),
-            None => None,
-        }
+        self.as_str().get(start..end).map(|_| Span {
+            input: self.input,
+            start: self.start + start,
+            end: self.start + end,
+        })
     }
 
     /// Returns the `Span`'s start byte position as a `usize`.

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -9,7 +9,7 @@
 
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::RangeBounds;
+use core::ops::{Bound, RangeBounds};
 use core::ptr;
 use core::str;
 
@@ -76,14 +76,14 @@ impl<'i> Span<'i> {
     /// # Examples
     pub fn get(&self, range: impl RangeBounds<usize>) -> Option<Span<'i>> {
         let start = match range.start_bound() {
-            std::ops::Bound::Included(offset) => *offset,
-            std::ops::Bound::Excluded(offset) => *offset + 1,
-            std::ops::Bound::Unbounded => 0,
+            Bound::Included(offset) => *offset,
+            Bound::Excluded(offset) => *offset + 1,
+            Bound::Unbounded => 0,
         };
         let end = match range.end_bound() {
-            std::ops::Bound::Included(offset) => *offset + 1,
-            std::ops::Bound::Excluded(offset) => *offset,
-            std::ops::Bound::Unbounded => self.as_str().len(),
+            Bound::Included(offset) => *offset + 1,
+            Bound::Excluded(offset) => *offset,
+            Bound::Unbounded => self.as_str().len(),
         };
 
         self.as_str().get(start..end).map(|_| Span {

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -9,6 +9,7 @@
 
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::ops::RangeBounds;
 use core::ptr;
 use core::str;
 
@@ -73,7 +74,7 @@ impl<'i> Span<'i> {
     /// ```
     ///
     /// # Examples
-    pub fn get(&self, range: impl std::ops::RangeBounds<usize>) -> Option<Span<'i>> {
+    pub fn get(&self, range: impl RangeBounds<usize>) -> Option<Span<'i>> {
         let start = match range.start_bound() {
             std::ops::Bound::Included(offset) => *offset,
             std::ops::Bound::Excluded(offset) => *offset + 1,

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -61,8 +61,7 @@ impl<'i> Span<'i> {
         }
     }
 
-    /// Attempts to create a new span within the bounds of `this` span. Will return `None` if
-    /// `range` does not fit within `this`.
+    /// Attempts to create a new span based on a sub-range.
     ///
     /// ```
     /// use pest::Span;


### PR DESCRIPTION
Partially revives #456 and merge would partially close #455.

This implementation changes the name of the new feature in #456 from `Span::sub_span` to `Span::get` to have parity with `str::get`.

This implementation does not require `std`.