### PR TITLE
doc: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting to know the project
 
-Before diving into the whys and hows, it's best one got started with the whats. The best place to learn about what pest does and what its limits are is the [book]. Feel free to try any of the examples in the [fiddle editor] as well.
+Before diving into the whys and hows, it's best one got started with the what's. The best place to learn about what pest does and what its limits are is the [book]. Feel free to try any of the examples in the [fiddle editor] as well.
 
 [book]: https://pest-parser.github.io/book
 [fiddle editor]: https://pest-parser.github.io/#editor

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Other helpful resources:
 
 ## Example
 
-The following is an example of a grammar for a list of alpha-numeric identifiers
+The following is an example of a grammar for a list of alphanumeric identifiers
 where the first identifier does not start with a digit:
 
 ```rust

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,7 +152,7 @@
 //!
 //! Strings and characters follow
 //! [Rust's escape mechanisms](https://doc.rust-lang.org/reference/tokens.html#byte-escapes), while
-//! identifiers can contain alpha-numeric characters and underscores (`_`), as long as they do not
+//! identifiers can contain alphanumeric characters and underscores (`_`), as long as they do not
 //! start with a digit.
 //!
 //! 2. Non-terminals
@@ -266,7 +266,7 @@
 //! ```
 //!
 //! For historical reasons, `PEEK_ALL` matches from top to bottom, while `PEEK[start..end]` matches
-//! from bottom to top. There is currectly no syntax to match a slice of the stack top to bottom.
+//! from bottom to top. There is currently no syntax to match a slice of the stack top to bottom.
 //!
 //! ## `Rule`
 //!


### PR DESCRIPTION
Found via `codespell -L crate,ser,complies`.