### PR TITLE
ci: release 2.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,57 +13,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@1.61.0
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing
         run: cargo run --package pest_bootstrap
-      # it should figure out the right order: https://github.com/katyo/publish-crates#features
-      - name: Publish pest
-        uses: katyo/publish-crates@v1
-        with:
-          path: './pest'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: update
-        run: cargo update
-      - name: Publish pest_meta
-        uses: katyo/publish-crates@v1
-        with:
-          path: './meta'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: update
-        run: cargo update
-      - name: Publish pest_vm
-        uses: katyo/publish-crates@v1
-        with:
-          path: './vm'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: update
-        run: cargo update
-      - name: Publish pest_generator
-        uses: katyo/publish-crates@v1
-        with:
-          path: './generator'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: update
-        run: cargo update
-      - name: Publish pest_derive
-        uses: katyo/publish-crates@v1
-        with:
-          path: './derive'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: update
-        run: cargo update
-      - name: Publish pest_grammars
-        uses: katyo/publish-crates@v1
-        with:
-          path: './grammars'
-          args: --allow-dirty --all-features
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish pest crates
+        run: ./release.sh

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -23,5 +23,5 @@ std = ["pest/std", "pest_generator/std"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.2.1", default-features = false }
-pest_generator = { path = "../generator", version = "2.2.1", default-features = false }
+pest = { path = "../pest", version = "2.3.0", default-features = false }
+pest_generator = { path = "../generator", version = "2.3.0", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -18,8 +18,8 @@ default = ["std"]
 std = ["pest/std"]
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.1", default-features = false }
-pest_meta = { path = "../meta", version = "2.2.1" }
+pest = { path = "../pest", version = "2.3.0", default-features = false }
+pest_meta = { path = "../meta", version = "2.3.0" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.1" }
-pest_derive = { path = "../derive", version = "2.2.1" }
+pest = { path = "../pest", version = "2.3.0" }
+pest_derive = { path = "../derive", version = "2.3.0" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.1" }
+pest = { path = "../pest", version = "2.3.0" }
 once_cell = "1.8.0"
 
 [build-dependencies]

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+CRATES="pest pest_meta pest_vm pest_generator pest_derive pest_grammars"
+
+get_local_version() {
+  cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "'"${1}"'" and ((.manifest_path|contains("registry"))|not))|.version'
+}
+
+check_version_online() {
+  curl -s "https://crates.io/api/v1/crates/${1}" | jq -r '.versions[]|select(.num == "'"${2}"'").updated_at'
+}
+
+get_manifest_path() {
+  cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "'"${1}"'" and ((.manifest_path|contains("registry"))|not))|.manifest_path'
+}
+
+publish() {
+  echo "Publishing crate $1..."
+  cargo publish --manifest-path "$(get_manifest_path "${1}")" --allow-dirty --all-features
+  echo ""
+}
+
+wait_until_available() {
+  echo "Waiting for crate ${1} to become available via crates.io..."
+  for retry in {1..5}; do
+    sleep 5
+    ONLINE_DATE="$(check_version_online "${1}" "${2}")"
+    if [ -n "${ONLINE_DATE}" ]; then
+      echo "Crate ${crate} is now available online"
+      break
+    else
+      if [ "${retry}" == 5 ]; then
+        echo "ERROR: Crate should have become available by now"
+        exit 1
+      else
+        echo "Not available just yet. Waiting a few seconds..."
+      fi
+    fi
+  done
+  echo "Waiting an additional 10 seconds for crate to propagate through CDN..."
+  sleep 10
+}
+
+for crate in ${CRATES}; do
+  VERSION="$(get_local_version "${crate}")"
+  publish "${crate}"
+  wait_until_available "${crate}" "${VERSION}"
+done

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2018"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
@@ -14,5 +14,5 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.2.1" }
-pest_meta = { path = "../meta", version = "2.2.1" }
+pest = { path = "../pest", version = "2.3.0" }
+pest_meta = { path = "../meta", version = "2.3.0" }


### PR DESCRIPTION
added a custom release bash script, because the previous GH action
failed at different stages, so a part of it needed to be published
manually. we'll see if this works this time.