### PR TITLE
fix: Search for grammar file from CARGO_MANIFEST_DIR

### DIFF
--- a/derive/tests/grammar.rs
+++ b/derive/tests/grammar.rs
@@ -16,7 +16,7 @@ extern crate pest;
 extern crate pest_derive;
 
 #[derive(Parser)]
-#[grammar = "../tests/grammar.pest"]
+#[grammar = "tests/grammar.pest"]
 struct GrammarParser;
 
 #[test]


### PR DESCRIPTION
This is a proposeal to fix #325.

The new logic looks for the `[grammar = "$path"]` path in `CARGO_MANIFEST_DIR/` before using the fallback of `CARGO_MANIFEST_DIR/src`.

This allows projects that don't have a `src` folder to use a grammar file, while staying backward compatible.

**Alternative implementation approach:**

One could theoretically use the [absolute](https://doc.rust-lang.org/std/path/fn.absolute.html) function.
Sadly, this function is still nightly, which makes this approach unfeasible.


**Current workarounds:**
- Restructure the project so it has a `src` folder
- Create a stub `src` folder, so one can use relative paths
- Inline all of the grammar via `grammar_inline`