### PR TITLE
Update deps and swith to 2021 edition

### DIFF
--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_bootstrap"
 description = "pest bootstrap script"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_derive"
 description = "pest's derive macro"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_generator"
 description = "pest code generator"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_grammars"
 description = "pest popular grammar implementations"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_meta"
 description = "pest meta language parser and validator"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest"
 description = "The Elegant Parser"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"
@@ -26,9 +26,9 @@ const_prec_climber = []
 fast-line-col = ["memchr", "bytecount"]
 
 [dependencies]
-ucd-trie = { version = "0.1.1", default-features = false }
-serde = { version = "1.0.89", optional = true }
-serde_json = { version = "1.0.39", optional = true}
-thiserror = { version = "1.0.31", optional = true }
+ucd-trie = { version = "0.1.5", default-features = false }
+serde = { version = "1.0.145", optional = true }
+serde_json = { version = "1.0.85", optional = true}
+thiserror = { version = "1.0.37", optional = true }
 memchr = { version = "2", optional = true }
 bytecount = { version = "0.6", optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pest_vm"
 description = "pest grammar virtual machine"
 version = "2.4.0"
-edition = "2018"
+edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest-parser.github.io/"
 repository = "https://github.com/pest-parser/pest"


### PR DESCRIPTION
cargo bootstrap and build run fine.
Update to 2021 edition.
Update to latest ucd-trie, serde, serde_json, thiserror.