### PR TITLE
chore: clippy fixes and ignores

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -55,10 +55,10 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
             // reasons.
             // TODO: This could be refactored once `std::path::absolute()` get's stabilized.
             // https://doc.rust-lang.org/std/path/fn.absolute.html
-            let path = if Path::new(&root).join(&path).exists() {
-                Path::new(&root).join(&path)
+            let path = if Path::new(&root).join(path).exists() {
+                Path::new(&root).join(path)
             } else {
-                Path::new(&root).join("src/").join(&path)
+                Path::new(&root).join("src/").join(path)
             };
 
             let file_name = match path.file_name() {

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -34,6 +34,7 @@ mod grammar {
 pub use self::grammar::*;
 
 /// A helper that will parse using the pest grammar
+#[allow(clippy::perf)]
 pub fn parse(rule: Rule, data: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
     PestParser::parse(rule, data)
 }

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -170,7 +170,7 @@ impl<R: RuleType> Error<R> {
         };
         let ll = line_iter.last();
         let continued_line = if visualize_ws {
-            ll.map(&str::to_owned)
+            ll.map(str::to_owned)
         } else {
             ll.map(visualize_whitespace)
         };

--- a/pest/src/parser.rs
+++ b/pest/src/parser.rs
@@ -14,5 +14,6 @@ use crate::RuleType;
 /// A trait with a single method that parses strings.
 pub trait Parser<R: RuleType> {
     /// Parses a `&str` starting from `rule`.
+    #[allow(clippy::perf)]
     fn parse(rule: R, input: &str) -> Result<Pairs<'_, R>, Error<R>>;
 }

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -147,6 +147,7 @@ pub struct ParserState<'i, R: RuleType> {
 /// let input = "";
 /// pest::state::<(), _>(input, |s| Ok(s)).unwrap();
 /// ```
+#[allow(clippy::perf)]
 pub fn state<'i, R: RuleType, F>(input: &'i str, f: F) -> Result<pairs::Pairs<'i, R>, Error<R>>
 where
     F: FnOnce(Box<ParserState<'i, R>>) -> ParseResult<Box<ParserState<'i, R>>>,
@@ -657,6 +658,9 @@ impl<'i, R: RuleType> ParserState<'i, R> {
 
     /// Attempts to match a single character from the given range. Returns `Ok` with the updated
     /// `Box<ParserState>` if successful, or `Err` with the updated `Box<ParserState>` otherwise.
+    ///
+    /// # Caution
+    /// The provided `range` is intepreted as inclusive.
     ///
     /// # Examples
     ///

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -225,7 +225,7 @@ impl<'i> Position<'i> {
         let skipped = {
             let mut len = 0;
             // Position's pos is always a UTF-8 border.
-            let mut chars = (&self.input[self.pos..]).chars();
+            let mut chars = self.input[self.pos..].chars();
             for _ in 0..n {
                 if let Some(c) = chars.next() {
                     len += c.len_utf8();
@@ -247,7 +247,7 @@ impl<'i> Position<'i> {
         let skipped = {
             let mut len = 0;
             // Position's pos is always a UTF-8 border.
-            let mut chars = (&self.input[..self.pos]).chars().rev();
+            let mut chars = self.input[..self.pos].chars().rev();
             for _ in 0..n {
                 if let Some(c) = chars.next() {
                     len += c.len_utf8();
@@ -301,7 +301,7 @@ impl<'i> Position<'i> {
     where
         F: FnOnce(char) -> bool,
     {
-        if let Some(c) = (&self.input[self.pos..]).chars().next() {
+        if let Some(c) = self.input[self.pos..].chars().next() {
             if f(c) {
                 self.pos += c.len_utf8();
                 true
@@ -352,7 +352,7 @@ impl<'i> Position<'i> {
     /// otherwise. If no match was made, `pos` will not be updated.
     #[inline]
     pub(crate) fn match_range(&mut self, range: Range<char>) -> bool {
-        if let Some(c) = (&self.input[self.pos..]).chars().next() {
+        if let Some(c) = self.input[self.pos..].chars().next() {
             if range.start <= c && c <= range.end {
                 self.pos += c.len_utf8();
                 return true;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -40,6 +40,7 @@ impl Vm {
     }
 
     /// Runs a parser rule on an input
+    #[allow(clippy::perf)]
     pub fn parse<'a, 'i>(
         &'a self,
         rule: &'a str,
@@ -48,6 +49,7 @@ impl Vm {
         pest::state(input, |state| self.parse_rule(rule, state))
     }
 
+    #[allow(clippy::suspicious)]
     fn parse_rule<'a, 'i>(
         &'a self,
         rule: &'a str,


### PR DESCRIPTION
code was fixed where possible;
elsewhere it'd need API-breaking changes,
so it was just annotated to allow that for now.