### PR TITLE
perf: optimize `skip_until` using memchr and aho-corasick

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 [features]
 default = ["std"]
 # Implements `std::error::Error` for the `Error` type
-std = ["ucd-trie/std", "thiserror"]
+std = ["aho-corasick/std", "memchr/std", "ucd-trie/std", "thiserror"]
 # Enables the `to_json` function for `Pair` and `Pairs`
 pretty-print = ["serde", "serde_json"]
 # Enable const fn constructor for `PrecClimber`
@@ -30,5 +30,11 @@ ucd-trie = { version = "0.1.5", default-features = false }
 serde = { version = "1.0.145", optional = true }
 serde_json = { version = "1.0.85", optional = true}
 thiserror = { version = "1.0.37", optional = true }
-memchr = { version = "2", optional = true }
 bytecount = { version = "0.6", optional = true }
+
+[target.'cfg(any(target_feature = "sse2", target_feature = "simd128"))'.dependencies]
+aho-corasick = { version = "0.7", default-features = false }
+memchr = { version = "2", default-features = false }
+
+[target.'cfg(not(any(target_feature = "sse2", target_feature = "simd128")))'.dependencies]
+memchr = { version = "2", optional = true, default-features = false }


### PR DESCRIPTION
so far, SIMD support is only available for x86_64 and wasm