### PR TITLE
Fix unexpected argument panic in `pest_debugger`

### DIFF
--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -198,6 +198,7 @@ impl Default for CliArgs {
         };
         let args = std::env::args();
         let mut iter = args.skip(1);
+        let mut unexpected_arg = false;
         while let Some(arg) = iter.next() {
             match arg.as_str() {
                 "-g" | "--grammar" => {
@@ -256,8 +257,14 @@ impl Default for CliArgs {
                     );
                     std::process::exit(0);
                 }
-                _ => unreachable!(),
+                arg => {
+                    eprintln!("Error: unexpected argument `{}`", arg);
+                    unexpected_arg = true;
+                },
             }
+        }
+        if unexpected_arg {
+            std::process::exit(1);
         }
         result
     }

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -260,7 +260,7 @@ impl Default for CliArgs {
                 arg => {
                     eprintln!("Error: unexpected argument `{}`", arg);
                     unexpected_arg = true;
-                },
+                }
             }
         }
         if unexpected_arg {


### PR DESCRIPTION
Fixes a panic when you provide the debugger executable with an argument it does not expect. It now exits gracefully.

before:
```
$ pest_debugger random args
thread 'main' panicked at 'internal error: entered unreachable code', /home/USERNAME/.cargo/registry/src/github.com-1ecc6299db9ec823/pest_debugger-2.5.0/src/main.rs:259:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after:
```
$ pest_debugger random args
Error: unexpected argument `random`
Error: unexpected argument `args`
```