### PR TITLE
doc: fix tables of (non-)terminals

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,12 +152,12 @@
 //!
 //! 1. Terminals
 //!
-//!     | Terminal   | Usage                                                          |
-//!     |------------|----------------------------------------------------------------|
-//!     | `"a"`      | matches the exact string `"a"`                                 |
-//!     | `^"a"`     | matches the exact string `"a"` case insensitively (ASCII only) |
-//!     | `'a'..'z'` | matches one character between `'a'` and `'z'`                  |
-//!     | `a`        | matches rule `a`                                               |
+//! | Terminal   | Usage                                                          |
+//! |------------|----------------------------------------------------------------|
+//! | `"a"`      | matches the exact string `"a"`                                 |
+//! | `^"a"`     | matches the exact string `"a"` case insensitively (ASCII only) |
+//! | `'a'..'z'` | matches one character between `'a'` and `'z'`                  |
+//! | `a`        | matches rule `a`                                               |
 //!
 //! Strings and characters follow
 //! [Rust's escape mechanisms](https://doc.rust-lang.org/reference/tokens.html#byte-escapes), while
@@ -166,23 +166,23 @@
 //!
 //! 2. Non-terminals
 //!
-//!     | Non-terminal          | Usage                                                      |
-//!     |-----------------------|------------------------------------------------------------|
-//!     | `(e)`                 | matches `e`                                                |
-//!     | `e1 ~ e2`             | matches the sequence `e1` `e2`                             |
-//!     | <code>e1 \| e2</code> | matches either `e1` or `e2`                                |
-//!     | `e*`                  | matches `e` zero or more times                             |
-//!     | `e+`                  | matches `e` one or more times                              |
-//!     | `e{n}`                | matches `e` exactly `n` times                              |
-//!     | `e{, n}`              | matches `e` at most `n` times                              |
-//!     | `e{n,} `              | matches `e` at least `n` times                             |
-//!     | `e{m, n}`             | matches `e` between `m` and `n` times inclusively          |
-//!     | `e?`                  | optionally matches `e`                                     |
-//!     | `&e`                  | matches `e` without making progress                        |
-//!     | `!e`                  | matches if `e` doesn't match without making progress       |
-//!     | `PUSH(e)`             | matches `e` and pushes it's captured string down the stack |
+//! | Non-terminal          | Usage                                                      |
+//! |-----------------------|------------------------------------------------------------|
+//! | `(e)`                 | matches `e`                                                |
+//! | `e1 ~ e2`             | matches the sequence `e1` `e2`                             |
+//! | <code>e1 \| e2</code> | matches either `e1` or `e2`                                |
+//! | `e*`                  | matches `e` zero or more times                             |
+//! | `e+`                  | matches `e` one or more times                              |
+//! | `e{n}`                | matches `e` exactly `n` times                              |
+//! | `e{, n}`              | matches `e` at most `n` times                              |
+//! | `e{n,}`               | matches `e` at least `n` times                             |
+//! | `e{m, n}`             | matches `e` between `m` and `n` times inclusively          |
+//! | `e?`                  | optionally matches `e`                                     |
+//! | `&e`                  | matches `e` without making progress                        |
+//! | `!e`                  | matches if `e` doesn't match without making progress       |
+//! | `PUSH(e)`             | matches `e` and pushes it's captured string down the stack |
 //!
-//!     where `e`, `e1`, and `e2` are expressions.
+//! where `e`, `e1`, and `e2` are expressions.
 //!
 //! Expressions can modify the stack only if they match the input. For example,
 //! if `e1` in the compound expression `e1 | e2` does not match the input, then

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -165,12 +165,12 @@
 //!
 //! 1. Terminals
 //!
-//!     | Terminal   | Usage                                                          |
-//!     |------------|----------------------------------------------------------------|
-//!     | `"a"`      | matches the exact string `"a"`                                 |
-//!     | `^"a"`     | matches the exact string `"a"` case insensitively (ASCII only) |
-//!     | `'a'..'z'` | matches one character between `'a'` and `'z'`                  |
-//!     | `a`        | matches rule `a`                                               |
+//! | Terminal   | Usage                                                          |
+//! |------------|----------------------------------------------------------------|
+//! | `"a"`      | matches the exact string `"a"`                                 |
+//! | `^"a"`     | matches the exact string `"a"` case insensitively (ASCII only) |
+//! | `'a'..'z'` | matches one character between `'a'` and `'z'`                  |
+//! | `a`        | matches rule `a`                                               |
 //!
 //! Strings and characters follow
 //! [Rust's escape mechanisms](https://doc.rust-lang.org/reference/tokens.html#byte-escapes), while
@@ -179,23 +179,23 @@
 //!
 //! 2. Non-terminals
 //!
-//!     | Non-terminal          | Usage                                                      |
-//!     |-----------------------|------------------------------------------------------------|
-//!     | `(e)`                 | matches `e`                                                |
-//!     | `e1 ~ e2`             | matches the sequence `e1` `e2`                             |
-//!     | <code>e1 \| e2</code> | matches either `e1` or `e2`                                |
-//!     | `e*`                  | matches `e` zero or more times                             |
-//!     | `e+`                  | matches `e` one or more times                              |
-//!     | `e{n}`                | matches `e` exactly `n` times                              |
-//!     | `e{, n}`              | matches `e` at most `n` times                              |
-//!     | `e{n,} `              | matches `e` at least `n` times                             |
-//!     | `e{m, n}`             | matches `e` between `m` and `n` times inclusively          |
-//!     | `e?`                  | optionally matches `e`                                     |
-//!     | `&e`                  | matches `e` without making progress                        |
-//!     | `!e`                  | matches if `e` doesn't match without making progress       |
-//!     | `PUSH(e)`             | matches `e` and pushes it's captured string down the stack |
+//! | Non-terminal          | Usage                                                      |
+//! |-----------------------|------------------------------------------------------------|
+//! | `(e)`                 | matches `e`                                                |
+//! | `e1 ~ e2`             | matches the sequence `e1` `e2`                             |
+//! | <code>e1 \| e2</code> | matches either `e1` or `e2`                                |
+//! | `e*`                  | matches `e` zero or more times                             |
+//! | `e+`                  | matches `e` one or more times                              |
+//! | `e{n}`                | matches `e` exactly `n` times                              |
+//! | `e{, n}`              | matches `e` at most `n` times                              |
+//! | `e{n,}`               | matches `e` at least `n` times                             |
+//! | `e{m, n}`             | matches `e` between `m` and `n` times inclusively          |
+//! | `e?`                  | optionally matches `e`                                     |
+//! | `&e`                  | matches `e` without making progress                        |
+//! | `!e`                  | matches if `e` doesn't match without making progress       |
+//! | `PUSH(e)`             | matches `e` and pushes it's captured string down the stack |
 //!
-//!     where `e`, `e1`, and `e2` are expressions.
+//! where `e`, `e1`, and `e2` are expressions.
 //!
 //! Expressions can modify the stack only if they match the input. For example,
 //! if `e1` in the compound expression `e1 | e2` does not match the input, then


### PR DESCRIPTION
For some reason, rustdoc does not recognize the table when it is indented.  (This behavior seems to have changed between the 2.0 and 2.1 builds on docs.rs, while the markup stayed unchanged.)