### PR TITLE
perf: add a faster skip_until using SIMD memchr

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>", "Tomas Tauber <me@tomtau.be>"]
 homepage = "https://pest.rs/"
@@ -14,9 +14,9 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.0" }
-pest_meta = { path = "../meta", version = "2.5.0" }
-pest_vm = { path = "../vm", version = "2.5.0" }
+pest = { path = "../pest", version = "2.5.1" }
+pest_meta = { path = "../meta", version = "2.5.1" }
+pest_vm = { path = "../vm", version = "2.5.1" }
 rustyline = "10"
 thiserror = "1"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -23,5 +23,5 @@ std = ["pest/std", "pest_generator/std"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.5.0", default-features = false }
-pest_generator = { path = "../generator", version = "2.5.0", default-features = false }
+pest = { path = "../pest", version = "2.5.1", default-features = false }
+pest_generator = { path = "../generator", version = "2.5.1", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -18,8 +18,8 @@ default = ["std"]
 std = ["pest/std"]
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.0", default-features = false }
-pest_meta = { path = "../meta", version = "2.5.0" }
+pest = { path = "../pest", version = "2.5.1", default-features = false }
+pest_meta = { path = "../meta", version = "2.5.1" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.0" }
-pest_derive = { path = "../derive", version = "2.5.0" }
+pest = { path = "../pest", version = "2.5.1" }
+pest_derive = { path = "../derive", version = "2.5.1" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.0" }
+pest = { path = "../pest", version = "2.5.1" }
 once_cell = "1.8.0"
 
 [build-dependencies]

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,5 +14,5 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.0" }
-pest_meta = { path = "../meta", version = "2.5.0" }
+pest = { path = "../pest", version = "2.5.1" }
+pest_meta = { path = "../meta", version = "2.5.1" }


### PR DESCRIPTION
it was put under the "memchr" feature-flag, as memchr SIMD support is only on x86_64 at the moment (json bench is ~8% faster over baseline there): https://github.com/pest-parser/pest/pull/737#issuecomment-1325784358 once memchr has the Arm SIMD support, this could be perhaps the default implementation.
For Aho-Corasick, it'll require more investigation.