### PR TITLE
Allow use of rust keywords as pest rules

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -182,9 +182,7 @@ fn generate_include(name: &Ident, path: &str) -> TokenStream {
 }
 
 fn generate_enum(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
-    let rules = rules
-        .iter()
-        .map(|rule| format_ident!("r#{}", rule.name));
+    let rules = rules.iter().map(|rule| format_ident!("r#{}", rule.name));
     if uses_eoi {
         quote! {
             #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
@@ -962,15 +960,18 @@ mod tests {
         let name = Ident::new("MyParser", Span::call_site());
         let generics = Generics::default();
 
-        let rules = vec![OptimizedRule {
-            name: "a".to_owned(),
-            ty: RuleType::Silent,
-            expr: OptimizedExpr::Str("b".to_owned()),
-        }, OptimizedRule {
-            name: "if".to_owned(),
-            ty: RuleType::Silent,
-            expr: OptimizedExpr::Ident("a".to_owned())
-        }];
+        let rules = vec![
+            OptimizedRule {
+                name: "a".to_owned(),
+                ty: RuleType::Silent,
+                expr: OptimizedExpr::Str("b".to_owned()),
+            },
+            OptimizedRule {
+                name: "if".to_owned(),
+                ty: RuleType::Silent,
+                expr: OptimizedExpr::Ident("a".to_owned()),
+            },
+        ];
 
         let defaults = vec!["ANY"];
         let result = result_type();

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -9,7 +9,7 @@
 
 use std::path::PathBuf;
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{self, Generics, Ident};
 

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -184,7 +184,7 @@ fn generate_include(name: &Ident, path: &str) -> TokenStream {
 fn generate_enum(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
     let rules = rules
         .iter()
-        .map(|rule| format_ident!("r#{}", rule.name.as_str()));
+        .map(|rule| format_ident!("r#{}", rule.name));
     if uses_eoi {
         quote! {
             #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
@@ -209,7 +209,7 @@ fn generate_patterns(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
     let mut rules: Vec<TokenStream> = rules
         .iter()
         .map(|rule| {
-            let rule = format_ident!("r#{}", Ident::new(rule.name.as_str(), Span::call_site()));
+            let rule = format_ident!("r#{}", rule.name);
             quote! {
                 Rule::#rule => rules::#rule(state)
             }
@@ -228,7 +228,7 @@ fn generate_patterns(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
 }
 
 fn generate_rule(rule: OptimizedRule) -> TokenStream {
-    let name = format_ident!("r#{}", Ident::new(&rule.name, Span::call_site()));
+    let name = format_ident!("r#{}", rule.name);
 
     let expr = if rule.ty == RuleType::Atomic || rule.ty == RuleType::CompoundAtomic {
         generate_expr_atomic(rule.expr)
@@ -676,7 +676,7 @@ mod tests {
                 #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
                 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
                 pub enum Rule {
-                    f
+                    r#f
                 }
             }
             .to_string()
@@ -864,7 +864,7 @@ mod tests {
         assert_eq!(
             generate_expr(expr).to_string(),
             quote! {
-                self::a(state).or_else(|state| {
+                self::r#a(state).or_else(|state| {
                     state.sequence(|state| {
                         state.match_range('a'..'b').and_then(|state| {
                             super::hidden::skip(state)
@@ -930,7 +930,7 @@ mod tests {
         assert_eq!(
             generate_expr_atomic(expr).to_string(),
             quote! {
-                self::a(state).or_else(|state| {
+                self::r#a(state).or_else(|state| {
                     state.sequence(|state| {
                         state.match_range('a'..'b').and_then(|state| {
                             state.lookahead(false, |state| {
@@ -969,7 +969,7 @@ mod tests {
         }, OptimizedRule {
             name: "if".to_owned(),
             ty: RuleType::Silent,
-            expr: OptimizedExpr::Str("c".to_owned())
+            expr: OptimizedExpr::Ident("a".to_owned())
         }];
 
         let defaults = vec!["ANY"];
@@ -1024,7 +1024,7 @@ mod tests {
                                 #[inline]
                                 #[allow(non_snake_case, unused_variables)]
                                 pub fn r#if(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
-                                    state.match_string("c")
+                                    self::r#a(state)
                                 }
 
                                 #[inline]

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -227,10 +227,9 @@ fn generate_patterns(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
 
 fn generate_rule(rule: OptimizedRule) -> TokenStream {
     let name = format_ident!("r#{}", rule.name);
-
     let expr = if rule.ty == RuleType::Atomic || rule.ty == RuleType::CompoundAtomic {
         generate_expr_atomic(rule.expr)
-    } else if name == "WHITESPACE" || name == "COMMENT" {
+    } else if rule.name == "WHITESPACE" || rule.name == "COMMENT" {
         let atomic = generate_expr_atomic(rule.expr);
 
         quote! {
@@ -658,6 +657,8 @@ fn option_type() -> TokenStream {
 
 #[cfg(test)]
 mod tests {
+    use proc_macro2::Span;
+
     use super::*;
 
     #[test]

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -114,6 +114,28 @@ pub fn validate_pairs(pairs: Pairs<'_, Rule>) -> Result<Vec<&str>, Vec<Error<Rul
     Ok(defaults.cloned().collect())
 }
 
+/// Validates that the given `definitions` do not contain any Rust keywords.
+#[allow(clippy::ptr_arg)]
+#[deprecated = "Rust keywords are no longer restricted from the pest grammar"]
+pub fn validate_rust_keywords(definitions: &Vec<Span<'_>>) -> Vec<Error<Rule>> {
+    let mut errors = vec![];
+
+    for definition in definitions {
+        let name = definition.as_str();
+
+        if RUST_KEYWORDS.contains(name) {
+            errors.push(Error::new_from_span(
+                ErrorVariant::CustomError {
+                    message: format!("{} is a rust keyword", name),
+                },
+                *definition,
+            ))
+        }
+    }
+
+    errors
+}
+
 /// Validates that the given `definitions` do not contain any Pest keywords.
 #[allow(clippy::ptr_arg)]
 pub fn validate_pest_keywords(definitions: &Vec<Span<'_>>) -> Vec<Error<Rule>> {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -126,7 +126,7 @@ impl Vm {
         };
 
         if let Some(rule) = self.rules.get(rule) {
-            if &rule.name == "WHITESPACE" || &rule.name == "COMMENT" {
+            if rule.name == "WHITESPACE" || rule.name == "COMMENT" {
                 match rule.ty {
                     RuleType::Normal => state.rule(&rule.name, |state| {
                         state.atomic(Atomicity::Atomic, |state| {


### PR DESCRIPTION
This prefixes all non-builtin rules with `r#` to allow for use of rust keywords as pest rules. This is my first pull request so please let me know if I should make any changes.

This refactors code to use [`format_ident!`](https://docs.rs/quote/latest/quote/macro.format_ident.html) rather than `Ident::new` (with `format!` internally in the case of `_PEST_GRAMMAR_{}`), as it works the same internally, with the `Span` falling back to `Span::call_site()` when not given an `Ident`, so there shouldn't be any issues.

Updated test cases that use identifiers as expressions to test escaping them

Fixes #747 