### PR TITLE
Improve line, col calculate performance by use move cursor on Pairs Iterator.

### DIFF
--- a/grammars/benches/json.rs
+++ b/grammars/benches/json.rs
@@ -56,16 +56,37 @@ item = _{ SOI ~ line* ~ EOI }
     pub struct JsonParser;
 }
 
+// With 500 times iter
+// pair.line_col                                time:   [2.9937 µs 2.9975 µs 3.0018 µs]
+// position.line_col                            time:   [212.59 µs 213.38 µs 214.29 µs]
+// position.line_col (with fast-line-col)       time:   [18.241 µs 18.382 µs 18.655 µs]
+//
+// With 1000 times iter
+// pair.line_col                                time:   [10.814 µs 10.846 µs 10.893 µs]
+// position.line_col                            time:   [90.135 µs 93.901 µs 98.655 µs]
+// position.line_col (with fast-line-col)       time:   [1.7199 ms 1.7246 ms 1.7315 ms]
 fn line_col_benchmark(c: &mut Criterion) {
     let mut file = File::open("benches/main.i18n.json").unwrap();
     let mut data = String::new();
 
     file.read_to_string(&mut data).unwrap();
     let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, &data).unwrap();
-    let last_pair = pairs.last().unwrap();
-    c.bench_function("line col", |b| {
+
+    c.bench_function("pair.line_col", |b| {
         b.iter(|| {
-            last_pair.line_col();
+            let mut pairs = pairs.clone();
+            for _ in 0..500 {
+                pairs.next().unwrap().line_col();
+            }
+        })
+    });
+
+    c.bench_function("position.line_col", |b| {
+        b.iter(|| {
+            let mut pairs = pairs.clone();
+            for _ in 0..500 {
+                pairs.next().unwrap().as_span().start_pos().line_col();
+            }
         });
     });
 }

--- a/grammars/benches/json.rs
+++ b/grammars/benches/json.rs
@@ -65,7 +65,7 @@ fn line_col_benchmark(c: &mut Criterion) {
     let last_pair = pairs.last().unwrap();
     c.bench_function("line col", |b| {
         b.iter(|| {
-            let _ = last_pair.as_span().start_pos().line_col();
+            last_pair.line_col();
         });
     });
 }

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -107,7 +107,7 @@ impl<'i, R: RuleType> Iterator for FlatPairs<'i, R> {
             return None;
         }
 
-        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.start, None) };
+        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.start) };
         self.next_start();
 
         Some(pair)
@@ -122,7 +122,7 @@ impl<'i, R: RuleType> DoubleEndedIterator for FlatPairs<'i, R> {
 
         self.next_start_from_end();
 
-        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.end, None) };
+        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.end) };
 
         Some(pair)
     }

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -43,9 +43,7 @@ pub struct Pair<'i, R> {
     input: &'i str,
     /// Token index into `queue`.
     start: usize,
-
-    line: usize,
-    col: usize,
+    cursor: Option<Cursor>,
 }
 
 /// # Safety
@@ -55,14 +53,13 @@ pub unsafe fn new<R: RuleType>(
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &str,
     start: usize,
-    cursor: Cursor,
+    cursor: Option<Cursor>,
 ) -> Pair<'_, R> {
     Pair {
         queue,
         input,
         start,
-        line: cursor.line,
-        col: cursor.col,
+        cursor,
     }
 }
 
@@ -249,7 +246,10 @@ impl<'i, R: RuleType> Pair<'i, R> {
 
     /// Returns the `line`, `col` of this pair start.
     pub fn line_col(&self) -> (usize, usize) {
-        (self.line, self.col)
+        match &self.cursor {
+            Some(cursor) => (cursor.line, cursor.col),
+            None => self.as_span().start_pos().line_col(),
+        }
     }
 
     fn pair(&self) -> usize {

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -20,7 +20,7 @@ use core::str;
 #[cfg(feature = "pretty-print")]
 use serde::ser::SerializeStruct;
 
-use super::pairs::{self, Cursor, Pairs};
+use super::pairs::{self, Pairs};
 use super::queueable_token::QueueableToken;
 use super::tokens::{self, Tokens};
 use crate::span::{self, Span};
@@ -43,7 +43,7 @@ pub struct Pair<'i, R> {
     input: &'i str,
     /// Token index into `queue`.
     start: usize,
-    cursor: Option<Cursor>,
+    pub(crate) line_col: Option<(usize, usize)>,
 }
 
 /// # Safety
@@ -53,13 +53,12 @@ pub unsafe fn new<R: RuleType>(
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &str,
     start: usize,
-    cursor: Option<Cursor>,
 ) -> Pair<'_, R> {
     Pair {
         queue,
         input,
         start,
-        cursor,
+        line_col: None,
     }
 }
 
@@ -246,8 +245,8 @@ impl<'i, R: RuleType> Pair<'i, R> {
 
     /// Returns the `line`, `col` of this pair start.
     pub fn line_col(&self) -> (usize, usize) {
-        match &self.cursor {
-            Some(cursor) => (cursor.line, cursor.col),
+        match &self.line_col {
+            Some(line_col) => (line_col.0, line_col.1),
             None => self.as_span().start_pos().line_col(),
         }
     }

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -20,7 +20,7 @@ use core::str;
 #[cfg(feature = "pretty-print")]
 use serde::ser::SerializeStruct;
 
-use super::pairs::{self, Pairs};
+use super::pairs::{self, Cursor, Pairs};
 use super::queueable_token::QueueableToken;
 use super::tokens::{self, Tokens};
 use crate::span::{self, Span};
@@ -43,6 +43,9 @@ pub struct Pair<'i, R> {
     input: &'i str,
     /// Token index into `queue`.
     start: usize,
+
+    line: usize,
+    col: usize,
 }
 
 /// # Safety
@@ -52,11 +55,14 @@ pub unsafe fn new<R: RuleType>(
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &str,
     start: usize,
+    cursor: Cursor,
 ) -> Pair<'_, R> {
     Pair {
         queue,
         input,
         start,
+        line: cursor.line,
+        col: cursor.col,
     }
 }
 
@@ -239,6 +245,11 @@ impl<'i, R: RuleType> Pair<'i, R> {
     #[cfg(feature = "pretty-print")]
     pub fn to_json(&self) -> String {
         ::serde_json::to_string_pretty(self).expect("Failed to pretty-print Pair to json.")
+    }
+
+    /// Returns the `line`, `col` of this pair start.
+    pub fn line_col(&self) -> (usize, usize) {
+        (self.line, self.col)
     }
 
     fn pair(&self) -> usize {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -38,7 +38,7 @@ impl Default for Cursor {
 }
 
 impl Cursor {
-    fn get(&self) -> (usize, usize) {
+    pub(crate) fn get(&self) -> (usize, usize) {
         (self.line, self.col)
     }
 }
@@ -264,7 +264,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
                     Rc::clone(&self.queue),
                     self.input,
                     self.start,
-                    self.cursor.clone(),
+                    Some(self.cursor.clone()),
                 )
             })
         } else {
@@ -335,14 +335,7 @@ impl<'i, R: RuleType> DoubleEndedIterator for Pairs<'i, R> {
 
         self.end = self.pair_from_end();
 
-        let pair = unsafe {
-            pair::new(
-                Rc::clone(&self.queue),
-                self.input,
-                self.end,
-                self.cursor.clone(),
-            )
-        };
+        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.end, None) };
 
         Some(pair)
     }

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -360,6 +360,7 @@ pub mod prec_climber;
 mod span;
 mod stack;
 mod token;
+
 #[doc(hidden)]
 pub mod unicode;
 

--- a/pest/src/macros.rs
+++ b/pest/src/macros.rs
@@ -329,6 +329,7 @@ pub mod tests {
         a,
         b,
         c,
+        d,
     }
 
     pub struct AbcParser;
@@ -345,6 +346,7 @@ pub mod tests {
                             .skip(1)
                     })
                     .and_then(|s| s.skip(1).unwrap().rule(Rule::c, |s| s.match_string("e")))
+                    .and_then(|s| s.optional(|s| s.rule(Rule::d, |s| s.match_string("fgh"))))
             })
         }
     }

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -116,6 +116,10 @@ impl<'i> Position<'i> {
 
     /// Returns the line and column number of this `Position`.
     ///
+    /// This is an O(n) operation, where n is the number of lines in the input.
+    /// You better use `pair.line_col()` instead.
+    ///
+    ///
     /// # Examples
     ///
     /// ```

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -116,9 +116,8 @@ impl<'i> Position<'i> {
 
     /// Returns the line and column number of this `Position`.
     ///
-    /// This is an O(n) operation, where n is the number of lines in the input.
-    /// You better use `pair.line_col()` instead.
-    ///
+    /// This is an O(n) operation, where n is the number of chars in the input.
+    /// You better use [`pair.line_col()`](struct.Pair.html#method.line_col) instead.
     ///
     /// # Examples
     ///
@@ -139,14 +138,8 @@ impl<'i> Position<'i> {
         if self.pos > self.input.len() {
             panic!("position out of bounds");
         }
-        #[cfg(feature = "fast-line-col")]
-        {
-            fast_line_col(self.input, self.pos)
-        }
-        #[cfg(not(feature = "fast-line-col"))]
-        {
-            original_line_col(self.input, self.pos)
-        }
+
+        line_col(self.input, self.pos)
     }
 
     /// Returns the entire line of the input that contains this `Position`.
@@ -456,6 +449,17 @@ impl<'i> Hash for Position<'i> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.input as *const str).hash(state);
         self.pos.hash(state);
+    }
+}
+
+pub(crate) fn line_col(input: &str, pos: usize) -> (usize, usize) {
+    #[cfg(feature = "fast-line-col")]
+    {
+        fast_line_col(input, pos)
+    }
+    #[cfg(not(feature = "fast-line-col"))]
+    {
+        original_line_col(input, pos)
     }
 }
 


### PR DESCRIPTION
ref: #707, #560

This implementation is based by I use in AutoCorrect: https://github.com/huacnlee/autocorrect/blob/v2.5.5/autocorrect/src/result.rs#L267

## Add `line_col` method for get `(line, col)` in pair

```rust
let mut pairs = JSONParser::parse(Rule::a, "....").unwrap();
let pair = pairs.next().unwrap();
let (line, col) = pair.line_col()
```

In this method, line, col has managed by move_cursor on Pairs iterator `next` method. For a large input string this method will be faster, because it does not need to re-calculate all of the input string. The line, col value has been cached in the pair and accumulate by `next` method.

And I keep the old `line_col` method in `Position` struct, because I found that has been used in other without `Pairs` iterator. This method still works, but it will be slower than the new method.

## Benchmark

```
pair.line_col                              time:   [2.9937 µs 2.9975 µs 3.0018 µs]
position.line_col                          time:   [212.59 µs 213.38 µs 214.29 µs]
position.line_col (with fast-line-col)     time:   [18.241 µs 18.382 µs 18.655 µs]
```

> 🎊 9x fast than position.line_col  with `fast-line-col`
> 🌈 100x fast than old position.line_col  

## Limitation

This implementation only work for forward iteration for `Pairs`. So iterate backward will fallback to `Position::line_col` method.
