### PR TITLE
#763 Switches SHA1 for SHA2

### DIFF
--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -20,4 +20,4 @@ pest = { path = "../pest", version = "2.5.2" }
 once_cell = "1.8.0"
 
 [build-dependencies]
-sha1 = { version = "0.10", default-features = false }
+sha2 = { version = "0.10", default-features = false }

--- a/meta/build.rs
+++ b/meta/build.rs
@@ -1,6 +1,4 @@
-extern crate sha1;
-
-use sha1::{Digest, Sha1};
+use sha2::{Digest, Sha256};
 use std::env;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -25,7 +23,7 @@ fn main() {
 
     // If `grammar.pest` exists (we're building from git sources)
     if grammar_pest_path.exists() {
-        let mut sha = Sha1::default();
+        let mut sha = Sha256::default();
 
         let old_hash = File::open(&hash_path).ok().map(|mut file| {
             let mut s = String::new();


### PR DESCRIPTION
I submitted an issue (#763) about the problems depending on SHA1 is causing with some build systems and security.  This PR  removes the SHA1 library and replaces it with the SHA2 library.

I'm not sure what side effects this will have on the build though.  The change is in meta/build.rs, and it looks like SHA1 is only being used to name a grammar file that gets downloaded and compared before deciding to create a new grammar file.  This change would definitely cause that step to happen with the first new build after merge.