### PR TITLE
CI use Rust 1.62.0 for fix rustyline 10.1.0 `#[default]` compile error.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           kind: check
-          toolchain: 1.61.0
+          toolchain: 1.62.0
       - name: cargo check
         run: cargo check --all --all-features --all-targets
 
@@ -40,7 +40,7 @@ jobs:
         with:
           kind: check
           components: clippy, rustfmt
-          toolchain: 1.61.0
+          toolchain: 1.62.0
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
@@ -62,7 +62,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.61.0
+          toolchain: 1.62.0
       - name: cargo doc
         run: cargo doc --all --all-features
 
@@ -122,7 +122,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.61.0
+          toolchain: 1.62.0
       - name: Check feature powerset
         run: cargo hack check --feature-powerset --optional-deps --exclude-all-features --keep-going --lib --tests --ignore-private
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     types: [published]
 
 jobs:
-
   publish:
     name: Publish crates on release
     runs-on: ubuntu-latest
@@ -16,7 +15,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.61.0
+        uses: dtolnay/rust-toolchain@1.62.0
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing


### PR DESCRIPTION
https://github.com/pest-parser/pest/actions/runs/3946148398/jobs/6753649401

Ref:

- https://github.com/kkawakam/rustyline/compare/v10.0.0...v10.1.0
- https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1620-2022-06-30
- https://github.com/rust-lang/rust/pull/94457