### PR TITLE
Feature: Simple update checker for pest_debugger

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.56"
 pest = { path = "../pest", version = "2.5.4" }
 pest_meta = { path = "../meta", version = "2.5.4" }
 pest_vm = { path = "../vm", version = "2.5.4" }
-rustyline = "10"
-thiserror = "1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "default-tls"] }
+rustyline = "10"
 serde_json = "1"
+thiserror = "1"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.5.4"
+version = "2.5.2"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>", "Tomas Tauber <me@tomtau.be>"]
 homepage = "https://pest.rs/"
@@ -19,6 +19,8 @@ pest_meta = { path = "../meta", version = "2.5.4" }
 pest_vm = { path = "../vm", version = "2.5.4" }
 rustyline = "10"
 thiserror = "1"
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "default-tls"] }
+serde_json = "1"
 
 [badges]
 codecov = { repository = "pest-parser/pest" }

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.5.2"
+version = "2.5.4"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>", "Tomas Tauber <me@tomtau.be>"]
 homepage = "https://pest.rs/"

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -311,6 +311,7 @@ fn main() -> rustyline::Result<()> {
                 "/",
                 env!("CARGO_PKG_VERSION")
             ))
+            .timeout(Some(Duration::from_secs(5)))
             .build()
             .ok();
 

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -315,8 +315,7 @@ fn main() -> rustyline::Result<()> {
             .ok();
 
         if let Some(client) = client {
-            let opt = check_for_updates(client);
-            if let Some(new_version) = opt {
+            if let Some(new_version) = check_for_updates(client) {
                 println!(
                     "A new version of pest_debugger is available: v{}",
                     new_version
@@ -370,10 +369,9 @@ fn main() -> rustyline::Result<()> {
 fn check_for_updates(client: Client) -> Option<String> {
     let response = client
         .get("https://crates.io/api/v1/crates/pest_debugger")
-        .send()
-        .ok();
+        .send();
 
-    if let Some(response) = response {
+    if let Ok(response) = response {
         response
             .json::<serde_json::Value>()
             .ok()

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -373,18 +373,15 @@ fn check_for_updates(client: Client) -> Option<String> {
         .send();
 
     if let Ok(response) = response {
-        response
-            .json::<serde_json::Value>()
-            .ok()
-            .and_then(|json| {
-                let version = json["crate"]["max_version"].as_str()?;
+        response.json::<serde_json::Value>().ok().and_then(|json| {
+            let version = json["crate"]["max_version"].as_str()?;
 
-                if version != VERSION {
-                    Some(version.to_string())
-                } else {
-                    None
-                }
-            })
+            if version != VERSION {
+                Some(version.to_string())
+            } else {
+                None
+            }
+        })
     } else {
         None
     }


### PR DESCRIPTION
This PR adds a simple synchronous update checker for pest_debugger. If an update is found, the new version is printed to the console:

`A new version of pest_debugger is available: v3.9.4` 

Else, 

`pest_debugger is up to date`

is printed.

The implementation discards any errors that occur during update checking since the user doesn't really need to know about them - update checking is non-essential. It's using the crates.io API, which is subject to their [policies](https://crates.io/policies). From what I understand, making one request every time someone starts pest_debugger will be fine.

Open for any feedback, my first contribution to an open source Rust project.