### PR TITLE
Add `LineIndex` instead of `Pairs::move_cursor` for improve `Pairs::next` and `Pair::line_col` performance.

### DIFF
--- a/grammars/benches/json.rs
+++ b/grammars/benches/json.rs
@@ -85,6 +85,7 @@ fn bench_pairs_iter(c: &mut Criterion) {
 
     fn iter_all_pairs(pairs: pest::iterators::Pairs<autocorrect::Rule>) {
         for pair in pairs {
+            pair.line_col();
             iter_all_pairs(pair.into_inner());
         }
     }
@@ -99,8 +100,9 @@ fn bench_pairs_iter(c: &mut Criterion) {
         let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, &data).unwrap();
 
         b.iter(move || {
-            for _pair in pairs.clone().flatten().into_iter() {
+            for pair in pairs.clone().flatten().into_iter() {
                 // do nothing
+                pair.line_col();
             }
         });
     });

--- a/grammars/benches/json.rs
+++ b/grammars/benches/json.rs
@@ -78,9 +78,8 @@ fn bench_line_col(c: &mut Criterion) {
     });
 }
 
-// nested iter                             time:   [258.27 µs 260.05 µs 262.64 µs]
-// nested iter (fast-line-col)             time:   [14.943 µs 14.963 µs 14.993 µs]
-// flatten iter                            time:   [2.0367 µs 2.1104 µs 2.2144 µs]
+// pairs nested iter             time:   [2.0168 ms 2.0381 ms 2.0725 ms]
+// pairs flatten iter            time:   [4.5973 µs 4.6132 µs 4.6307 µs]
 fn bench_pairs_iter(c: &mut Criterion) {
     let data = include_str!("data.json");
 
@@ -90,13 +89,13 @@ fn bench_pairs_iter(c: &mut Criterion) {
         }
     }
 
-    c.bench_function("nested iter", |b| {
+    c.bench_function("pairs nested iter", |b| {
         let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, &data).unwrap();
 
         b.iter(move || iter_all_pairs(pairs.clone()));
     });
 
-    c.bench_function("flatten iter", |b| {
+    c.bench_function("pairs flatten iter", |b| {
         let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, &data).unwrap();
 
         b.iter(move || {

--- a/grammars/tests/examples.json
+++ b/grammars/tests/examples.json
@@ -26,7 +26,7 @@
     "0123456789": "digit",
     "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
     "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
-    "true": true,
+    "han": "你好", "true": true,
     "false": false,
     "null": null,
     "array":[  ],

--- a/grammars/tests/examples.line-col.txt
+++ b/grammars/tests/examples.line-col.txt
@@ -1,3 +1,4 @@
+
 (2:3) "JSON Test Pattern pass1"
 (3:4) "object with 1 member"
 (3:28) "array with 1 element"
@@ -43,8 +44,10 @@
 (27:16) "`1~!@#$%^&*()_+-={':[,]}|;.</>?"
 (28:5) "hex"
 (28:12) "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A"
-(29:5) "true"
-(29:13) true
+(29:5) "han"
+(29:12) "你好"
+(29:18) "true"
+(29:26) true
 (30:5) "false"
 (30:14) false
 (31:5) "null"

--- a/grammars/tests/json.rs
+++ b/grammars/tests/json.rs
@@ -160,10 +160,16 @@ fn object() {
 }
 
 #[test]
-fn examples() {
+fn test_json_parse() {
+    let raw = include_str!("examples.json");
+    let ast = JsonParser::parse(Rule::json, raw);
+    assert!(ast.is_ok());
+}
+
+#[test]
+fn test_line_col() {
     let raw = include_str!("examples.json");
     let pairs = JsonParser::parse(Rule::json, raw).unwrap();
-
     let expected = include_str!("examples.line-col.txt");
 
     // Test for flatten iter, and use span.start_pos().line_col()
@@ -177,12 +183,40 @@ fn examples() {
     }
     assert_eq!(expected.trim(), out.trim());
 
+    // Test for flatten iter, and use pair.line_col()
+    let mut out = String::new();
+    for pair in pairs.clone().flatten() {
+        let sub_pairs = pair.clone().into_inner();
+        if sub_pairs.count() == 0 {
+            let span = pair.as_span();
+            out.push_str(&build_line_col(pair.line_col(), span.as_str()));
+        }
+    }
+    assert_eq!(expected.trim(), out.trim());
+
+    // Test for flatten rev iter, and use pair.line_col()
+    let mut out = String::new();
+    for pair in pairs.clone().flatten().rev() {
+        let sub_pairs = pair.clone().into_inner();
+        if sub_pairs.count() == 0 {
+            let span = pair.as_span();
+            out.insert_str(0, &build_line_col(pair.line_col(), span.as_str()));
+        }
+    }
+    assert_eq!(expected.trim(), out.trim());
+
     // Test for nested iter, use pair.line_col()
     let mut out = String::new();
-    for pair in pairs {
+    for pair in pairs.clone() {
         out.push_str(&build_result_for_pair(pair.clone()));
     }
+    assert_eq!(expected.trim(), out.trim());
 
+    // Test for nested iter, use pair.line_col()
+    let mut out = String::new();
+    for pair in pairs.clone().rev() {
+        out.insert_str(0, &build_result_for_pair(pair.clone()));
+    }
     assert_eq!(expected.trim(), out.trim());
 }
 
@@ -199,6 +233,7 @@ fn build_result_for_pair(pair: pest::iterators::Pair<Rule>) -> String {
     let mut out = String::new();
 
     let sub_pairs = pair.clone().into_inner();
+
     if sub_pairs.clone().count() == 0 {
         out.push_str(&build_line_col(pair.line_col(), pair.as_str()));
     } else {

--- a/grammars/tests/json.rs
+++ b/grammars/tests/json.rs
@@ -183,6 +183,20 @@ fn test_line_col() {
     }
     assert_eq!(expected.trim(), out.trim());
 
+    // Test for nested iter, use pair.line_col()
+    let mut out = String::new();
+    for pair in pairs.clone() {
+        out.push_str(&build_result_for_pair(pair.clone()));
+    }
+    assert_eq!(expected.trim(), out.trim());
+
+    // Test for nested iter, use pair.line_col()
+    let mut out = String::new();
+    for pair in pairs.clone().rev() {
+        out.insert_str(0, &build_result_for_pair(pair.clone()));
+    }
+    assert_eq!(expected.trim(), out.trim());
+
     // Test for flatten iter, and use pair.line_col()
     let mut out = String::new();
     for pair in pairs.clone().flatten() {
@@ -202,20 +216,6 @@ fn test_line_col() {
             let span = pair.as_span();
             out.insert_str(0, &build_line_col(pair.line_col(), span.as_str()));
         }
-    }
-    assert_eq!(expected.trim(), out.trim());
-
-    // Test for nested iter, use pair.line_col()
-    let mut out = String::new();
-    for pair in pairs.clone() {
-        out.push_str(&build_result_for_pair(pair.clone()));
-    }
-    assert_eq!(expected.trim(), out.trim());
-
-    // Test for nested iter, use pair.line_col()
-    let mut out = String::new();
-    for pair in pairs.clone().rev() {
-        out.insert_str(0, &build_result_for_pair(pair.clone()));
     }
     assert_eq!(expected.trim(), out.trim());
 }

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -11,6 +11,7 @@ use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::fmt;
 
+use super::line_index::LineIndex;
 use super::pair::{self, Pair};
 use super::queueable_token::QueueableToken;
 use super::tokens::{self, Tokens};
@@ -28,6 +29,7 @@ pub struct FlatPairs<'i, R> {
     input: &'i str,
     start: usize,
     end: usize,
+    line_index: Rc<LineIndex>,
 }
 
 /// # Safety
@@ -42,6 +44,7 @@ pub unsafe fn new<R: RuleType>(
     FlatPairs {
         queue,
         input,
+        line_index: Rc::new(LineIndex::new(input)),
         start,
         end,
     }
@@ -107,7 +110,14 @@ impl<'i, R: RuleType> Iterator for FlatPairs<'i, R> {
             return None;
         }
 
-        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.start) };
+        let pair = unsafe {
+            pair::new(
+                Rc::clone(&self.queue),
+                self.input,
+                Rc::clone(&self.line_index),
+                self.start,
+            )
+        };
         self.next_start();
 
         Some(pair)
@@ -122,7 +132,14 @@ impl<'i, R: RuleType> DoubleEndedIterator for FlatPairs<'i, R> {
 
         self.next_start_from_end();
 
-        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.end) };
+        let pair = unsafe {
+            pair::new(
+                Rc::clone(&self.queue),
+                self.input,
+                Rc::clone(&self.line_index),
+                self.end,
+            )
+        };
 
         Some(pair)
     }
@@ -141,6 +158,7 @@ impl<'i, R: Clone> Clone for FlatPairs<'i, R> {
         FlatPairs {
             queue: Rc::clone(&self.queue),
             input: self.input,
+            line_index: Rc::clone(&self.line_index),
             start: self.start,
             end: self.end,
         }

--- a/pest/src/iterators/line_index.rs
+++ b/pest/src/iterators/line_index.rs
@@ -1,11 +1,11 @@
 //! `LineIndex` to make a line_offsets, each item is an byte offset (start from 0) of the beginning of the line.
 //!
-//! For example, the text: `"hello你好\nworld"`, the line_offsets will store `[0, 12]`.
+//! For example, the text: `"hello 你好\nworld"`, the line_offsets will store `[0, 13]`.
 //!
 //! Then `line_col` with a offset just need to find the line index by binary search.
 //!
 //! Inspired by rust-analyzer's `LineIndex`:
-//! https://github.com/rust-lang/rust/blob/1.67.0/src/tools/rust-analyzer/crates/ide-db/src/line_index.rs
+//! <https://github.com/rust-lang/rust/blob/1.67.0/src/tools/rust-analyzer/crates/ide-db/src/line_index.rs>
 use alloc::vec::Vec;
 
 #[derive(Clone)]
@@ -16,8 +16,7 @@ pub struct LineIndex {
 
 impl LineIndex {
     pub fn new(text: &str) -> LineIndex {
-        let mut line_offsets: Vec<usize> = Vec::new();
-        line_offsets.push(0);
+        let mut line_offsets: Vec<usize> = alloc::vec![0];
 
         let mut offset = 0;
 
@@ -50,31 +49,34 @@ impl LineIndex {
 mod tests {
     use super::*;
 
+    #[allow(clippy::zero_prefixed_literal)]
     #[test]
     fn test_line_index() {
-        let text = "hello你好A🎈C\nworld";
+        let text = "hello 你好 A🎈C\nworld";
         let table = [
             (00, 1, 1, 'h'),
             (01, 1, 2, 'e'),
             (02, 1, 3, 'l'),
             (03, 1, 4, 'l'),
             (04, 1, 5, 'o'),
-            (05, 1, 6, '你'),
-            (08, 1, 7, '好'),
-            (11, 1, 8, 'A'),
-            (12, 1, 9, '🎈'),
-            (16, 1, 10, 'C'),
-            (17, 1, 11, '\n'),
-            (18, 2, 1, 'w'),
-            (19, 2, 2, 'o'),
-            (20, 2, 3, 'r'),
-            (21, 2, 4, 'l'),
-            (22, 2, 5, 'd'),
+            (05, 1, 6, ' '),
+            (06, 1, 7, '你'),
+            (09, 1, 8, '好'),
+            (12, 1, 9, ' '),
+            (13, 1, 10, 'A'),
+            (14, 1, 11, '🎈'),
+            (18, 1, 12, 'C'),
+            (19, 1, 13, '\n'),
+            (20, 2, 1, 'w'),
+            (21, 2, 2, 'o'),
+            (22, 2, 3, 'r'),
+            (23, 2, 4, 'l'),
+            (24, 2, 5, 'd'),
         ];
 
         let index = LineIndex::new(text);
         for &(offset, line, col, c) in table.iter() {
-            let res = index.line_col(&text, offset);
+            let res = index.line_col(text, offset);
             assert_eq!(
                 (res.0, res.1),
                 (line, col),

--- a/pest/src/iterators/line_index.rs
+++ b/pest/src/iterators/line_index.rs
@@ -1,0 +1,70 @@
+//! `LineIndex` to make a line_offsets, each item is an offset (start from 0) of the beginning of the line.
+//!
+//! For example, the text: `"hello\nworld"`, the line_offsets will store `[0, 8]`.
+//!
+//! Then `line_col` with a offset just need to find the line index by binary search,
+//!
+//! - `line` is the index of the line_offsets
+//! - `col` is the offset minus the line start offset
+//!
+//! Inspired by rust-analyzer's `LineIndex`:
+//! https://github.com/rust-lang/rust/blob/1.67.0/src/tools/rust-analyzer/crates/ide-db/src/line_index.rs
+use alloc::vec::Vec;
+
+#[derive(Clone)]
+pub struct LineIndex {
+    /// Offset the the beginning of each line, zero-based
+    line_offsets: Vec<usize>,
+}
+
+impl LineIndex {
+    pub fn new(text: &str) -> LineIndex {
+        let mut line_offsets = Vec::new();
+        line_offsets.push(0);
+
+        let mut offset = 0;
+
+        for c in text.chars() {
+            offset += 1;
+            if c == '\n' {
+                line_offsets.push(offset)
+            }
+        }
+
+        LineIndex { line_offsets }
+    }
+
+    pub fn line_col(&self, offset: usize) -> (usize, usize) {
+        let line = self.line_offsets.partition_point(|&it| it <= offset) - 1;
+        let line_start_offset = self.line_offsets[line];
+        let col = offset - line_start_offset;
+
+        (line + 1, col + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_index() {
+        let text = "hello\nworld";
+        let table = [
+            (00, 1, 1),
+            (01, 1, 2),
+            (05, 1, 6),
+            (06, 2, 1),
+            (07, 2, 2),
+            (08, 2, 3),
+            (10, 2, 5),
+            (11, 2, 6),
+            (12, 2, 7),
+        ];
+
+        let index = LineIndex::new(text);
+        for &(offset, line, col) in &table {
+            assert_eq!(index.line_col(offset), (line, col));
+        }
+    }
+}

--- a/pest/src/iterators/line_index.rs
+++ b/pest/src/iterators/line_index.rs
@@ -1,11 +1,8 @@
-//! `LineIndex` to make a line_offsets, each item is an offset (start from 0) of the beginning of the line.
+//! `LineIndex` to make a line_offsets, each item is an byte offset (start from 0) of the beginning of the line.
 //!
-//! For example, the text: `"hello\nworld"`, the line_offsets will store `[0, 8]`.
+//! For example, the text: `"hello你好\nworld"`, the line_offsets will store `[0, 12]`.
 //!
-//! Then `line_col` with a offset just need to find the line index by binary search,
-//!
-//! - `line` is the index of the line_offsets
-//! - `col` is the offset minus the line start offset
+//! Then `line_col` with a offset just need to find the line index by binary search.
 //!
 //! Inspired by rust-analyzer's `LineIndex`:
 //! https://github.com/rust-lang/rust/blob/1.67.0/src/tools/rust-analyzer/crates/ide-db/src/line_index.rs
@@ -13,31 +10,37 @@ use alloc::vec::Vec;
 
 #[derive(Clone)]
 pub struct LineIndex {
-    /// Offset the the beginning of each line, zero-based
+    /// Offset (bytes) the the beginning of each line, zero-based
     line_offsets: Vec<usize>,
 }
 
 impl LineIndex {
     pub fn new(text: &str) -> LineIndex {
-        let mut line_offsets = Vec::new();
+        let mut line_offsets: Vec<usize> = Vec::new();
         line_offsets.push(0);
 
         let mut offset = 0;
 
         for c in text.chars() {
-            offset += 1;
+            offset += c.len_utf8();
             if c == '\n' {
-                line_offsets.push(offset)
+                line_offsets.push(offset);
             }
         }
 
         LineIndex { line_offsets }
     }
 
-    pub fn line_col(&self, offset: usize) -> (usize, usize) {
-        let line = self.line_offsets.partition_point(|&it| it <= offset) - 1;
-        let line_start_offset = self.line_offsets[line];
-        let col = offset - line_start_offset;
+    /// Returns (line, col) of pos.
+    ///
+    /// The pos is a byte offset, start from 0, e.g. "ab" is 2, "你好" is 6
+    pub fn line_col(&self, input: &str, pos: usize) -> (usize, usize) {
+        let line = self.line_offsets.partition_point(|&it| it <= pos) - 1;
+        let first_offset = self.line_offsets[line];
+
+        // Get line str from original input, then we can get column offset
+        let line_str = &input[first_offset..pos];
+        let col = line_str.chars().count();
 
         (line + 1, col + 1)
     }
@@ -49,22 +52,38 @@ mod tests {
 
     #[test]
     fn test_line_index() {
-        let text = "hello\nworld";
+        let text = "hello你好A🎈C\nworld";
         let table = [
-            (00, 1, 1),
-            (01, 1, 2),
-            (05, 1, 6),
-            (06, 2, 1),
-            (07, 2, 2),
-            (08, 2, 3),
-            (10, 2, 5),
-            (11, 2, 6),
-            (12, 2, 7),
+            (00, 1, 1, 'h'),
+            (01, 1, 2, 'e'),
+            (02, 1, 3, 'l'),
+            (03, 1, 4, 'l'),
+            (04, 1, 5, 'o'),
+            (05, 1, 6, '你'),
+            (08, 1, 7, '好'),
+            (11, 1, 8, 'A'),
+            (12, 1, 9, '🎈'),
+            (16, 1, 10, 'C'),
+            (17, 1, 11, '\n'),
+            (18, 2, 1, 'w'),
+            (19, 2, 2, 'o'),
+            (20, 2, 3, 'r'),
+            (21, 2, 4, 'l'),
+            (22, 2, 5, 'd'),
         ];
 
         let index = LineIndex::new(text);
-        for &(offset, line, col) in &table {
-            assert_eq!(index.line_col(offset), (line, col));
+        for &(offset, line, col, c) in table.iter() {
+            let res = index.line_col(&text, offset);
+            assert_eq!(
+                (res.0, res.1),
+                (line, col),
+                "Expected: ({}, {}, {}, {:?})",
+                offset,
+                line,
+                col,
+                c
+            );
         }
     }
 }

--- a/pest/src/iterators/mod.rs
+++ b/pest/src/iterators/mod.rs
@@ -10,6 +10,7 @@
 //! Types and iterators for parser output.
 
 mod flat_pairs;
+mod line_index;
 mod pair;
 pub(crate) mod pairs;
 mod queueable_token;

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -206,7 +206,13 @@ impl<'i, R: RuleType> Pair<'i, R> {
     pub fn into_inner(self) -> Pairs<'i, R> {
         let pair = self.pair();
 
-        pairs::new(self.queue, self.input, self.start + 1, pair)
+        pairs::new(
+            self.queue,
+            self.input,
+            Some(self.line_index),
+            self.start + 1,
+            pair,
+        )
     }
 
     /// Returns the `Tokens` for the `Pair`.
@@ -273,7 +279,13 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     /// Create a new `Pairs` iterator containing just the single `Pair`.
     pub fn single(pair: Pair<'i, R>) -> Self {
         let end = pair.pair();
-        pairs::new(pair.queue, pair.input, pair.start, end)
+        pairs::new(
+            pair.queue,
+            pair.input,
+            Some(pair.line_index),
+            pair.start,
+            end,
+        )
     }
 }
 

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -253,8 +253,8 @@ impl<'i, R: RuleType> Pair<'i, R> {
 
     /// Returns the `line`, `col` of this pair start.
     pub fn line_col(&self) -> (usize, usize) {
-        let start = self.pos(self.start);
-        self.line_index.line_col(start)
+        let pos = self.pos(self.start);
+        self.line_index.line_col(self.input, pos)
     }
 
     fn pair(&self) -> usize {

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -20,27 +20,12 @@ use core::str;
 use serde::ser::SerializeStruct;
 
 use super::flat_pairs::{self, FlatPairs};
+use super::line_index::LineIndex;
 use super::pair::{self, Pair};
 use super::queueable_token::QueueableToken;
 use super::tokens::{self, Tokens};
-use crate::{position, RuleType};
+use crate::RuleType;
 
-#[derive(Clone)]
-pub struct Cursor {
-    pub line: usize,
-    pub col: usize,
-    pub end: usize,
-}
-
-impl Default for Cursor {
-    fn default() -> Cursor {
-        Cursor {
-            line: 1,
-            col: 1,
-            end: 0,
-        }
-    }
-}
 /// An iterator over [`Pair`]s. It is created by [`pest::state`] and [`Pair::into_inner`].
 ///
 /// [`Pair`]: struct.Pair.html
@@ -52,7 +37,7 @@ pub struct Pairs<'i, R> {
     input: &'i str,
     start: usize,
     end: usize,
-    cursor: Cursor,
+    line_index: Rc<LineIndex>,
 }
 
 pub fn new<R: RuleType>(
@@ -66,7 +51,7 @@ pub fn new<R: RuleType>(
         input,
         start,
         end,
-        cursor: Cursor::default(),
+        line_index: Rc::new(LineIndex::new(input)),
     }
 }
 
@@ -199,7 +184,14 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     #[inline]
     pub fn peek(&self) -> Option<Pair<'i, R>> {
         if self.start < self.end {
-            Some(unsafe { pair::new(Rc::clone(&self.queue), self.input, self.start) })
+            Some(unsafe {
+                pair::new(
+                    Rc::clone(&self.queue),
+                    self.input,
+                    Rc::clone(&self.line_index),
+                    self.start,
+                )
+            })
         } else {
             None
         }
@@ -237,42 +229,13 @@ impl<'i, R: RuleType> Pairs<'i, R> {
             }
         }
     }
-
-    /// Move the cursor (line, col) by a part of the input.
-    fn move_cursor(&mut self, input: &str, start: usize, end: usize) -> (usize, usize) {
-        // Move cursor for some skiped characters (by skip(n))
-        let prev_end = self.cursor.end;
-        if prev_end != start {
-            self.move_cursor(input, prev_end, start);
-        }
-
-        let (prev_line, prev_col) = (self.cursor.line, self.cursor.col);
-
-        let part = &input[self.cursor.end..end];
-        let (l, c) = position::line_col(part, part.len(), (0, 0));
-
-        self.cursor.line += l;
-        // Has new line
-        if l > 0 {
-            self.cursor.col = c;
-        } else {
-            self.cursor.col += c;
-        }
-        self.cursor.end = end;
-
-        (prev_line, prev_col)
-    }
 }
 
 impl<'i, R: RuleType> Iterator for Pairs<'i, R> {
     type Item = Pair<'i, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut pair = self.peek()?;
-        let span = pair.as_span();
-
-        let (l, c) = self.move_cursor(self.input, span.start(), span.end());
-        pair.line_col = Some((l, c));
+        let pair = self.peek()?;
 
         self.start = self.pair() + 1;
         Some(pair)
@@ -287,7 +250,14 @@ impl<'i, R: RuleType> DoubleEndedIterator for Pairs<'i, R> {
 
         self.end = self.pair_from_end();
 
-        let pair = unsafe { pair::new(Rc::clone(&self.queue), self.input, self.end) };
+        let pair = unsafe {
+            pair::new(
+                Rc::clone(&self.queue),
+                self.input,
+                Rc::clone(&self.line_index),
+                self.end,
+            )
+        };
 
         Some(pair)
     }
@@ -478,26 +448,14 @@ mod tests {
         let pair = pairs.next().unwrap();
         assert_eq!(pair.as_str(), "abc");
         assert_eq!(pair.line_col(), (1, 1));
-        assert_eq!(
-            (pairs.cursor.line, pairs.cursor.col, pairs.cursor.end),
-            (1, 4, 3)
-        );
 
         let pair = pairs.next().unwrap();
         assert_eq!(pair.as_str(), "e");
         assert_eq!(pair.line_col(), (2, 1));
-        assert_eq!(
-            (pairs.cursor.line, pairs.cursor.col, pairs.cursor.end),
-            (2, 2, 5)
-        );
 
         let pair = pairs.next().unwrap();
         assert_eq!(pair.as_str(), "fgh");
         assert_eq!(pair.line_col(), (2, 2));
-        assert_eq!(
-            (pairs.cursor.line, pairs.cursor.col, pairs.cursor.end),
-            (2, 5, 8)
-        );
     }
 
     #[test]

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -43,15 +43,21 @@ pub struct Pairs<'i, R> {
 pub fn new<R: RuleType>(
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &str,
+    line_index: Option<Rc<LineIndex>>,
     start: usize,
     end: usize,
 ) -> Pairs<'_, R> {
+    let line_index = match line_index {
+        Some(line_index) => line_index,
+        None => Rc::new(LineIndex::new(input)),
+    };
+
     Pairs {
         queue,
         input,
         start,
         end,
-        line_index: Rc::new(LineIndex::new(input)),
+        line_index,
     }
 }
 

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -157,7 +157,7 @@ where
     match f(state) {
         Ok(state) => {
             let len = state.queue.len();
-            Ok(pairs::new(Rc::new(state.queue), input, 0, len))
+            Ok(pairs::new(Rc::new(state.queue), input, None, 0, len))
         }
         Err(mut state) => {
             let variant = if state.reached_call_limit() {


### PR DESCRIPTION
Add `LineIndex` instead of `Pairs::move_cursor` for improve Pairs iterate and `Pair::line_col` performance.

Resolve #784
Ref: https://github.com/rust-lang/rust/blob/1.67.0/src/tools/rust-analyzer/crates/ide-db/src/line_index.rs

Benchmark result:

> (Updated on 2022.02.02 18:00) After I fix to for support utf-8, the new `line-index` implementation of line_col benchmark result is close to `fast-line-col`.
> But when In a last file, `line-index` will faster. 

Benchmark file: https://github.com/pest-parser/pest/blob/16de4fa29228ab07a8c49279de6c5f9814496ed6/grammars/benches/json.rs

```
// With 500 times iter
pair.line_col (with LineIndex)               time:   [22.426 µs 22.489 µs 22.556 µs]
position.line_col                            time:   [212.59 µs 213.38 µs 214.29 µs]
position.line_col (with fast-line-col)       time:   [18.241 µs 18.382 µs 18.655 µs]

// With 1000 times iter
pair.line_col (with LineIndex)               time:   [41.160 µs 41.969 µs 43.478 µs]
position.line_col                            time:   [1.7199 ms 1.7246 ms 1.7315 ms]
position.line_col (with fast-line-col)       time:   [48.498 µs 49.450 µs 50.877 µs]

// With 10K times iter
pair.line_col                                time:   [471.75 µs 475.03 µs 478.94 µs]
position.line_col (with fast-line-col)       time:   [8.1941 ms 8.3278 ms 8.5144 ms]
```

And I also tested the cost of `Pairs` iterate.

```
// Before changes
pairs nested iter                    time:   [2.0168 ms 2.0381 ms 2.0725 ms]
pairs flatten iter                   time:   [4.5973 µs 4.6132 µs 4.6307 µs]

// After added LineIndex
pairs nested iter (with LineIndex)   time:   [14.716 µs 14.822 µs 14.964 µs]
pairs flatten iter (with LineIndex)  time:   [5.4637 µs 5.6061 µs 5.7886 µs]
```

