### PR TITLE
chore: added docs for semver changes in grammar + remove fast-col-line

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>", "Tomas Tauber <me@tomtau.be>"]
 homepage = "https://pest.rs/"
@@ -14,9 +14,9 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.4" }
-pest_meta = { path = "../meta", version = "2.5.4" }
-pest_vm = { path = "../vm", version = "2.5.4" }
+pest = { path = "../pest", version = "2.5.5" }
+pest_meta = { path = "../meta", version = "2.5.5" }
+pest_vm = { path = "../vm", version = "2.5.5" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "default-tls"] }
 rustyline = "10"
 serde_json = "1"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -23,5 +23,5 @@ std = ["pest/std", "pest_generator/std"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.5.4", default-features = false }
-pest_generator = { path = "../generator", version = "2.5.4", default-features = false }
+pest = { path = "../pest", version = "2.5.5", default-features = false }
+pest_generator = { path = "../generator", version = "2.5.5", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -18,8 +18,8 @@ default = ["std"]
 std = ["pest/std"]
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.4", default-features = false }
-pest_meta = { path = "../meta", version = "2.5.4" }
+pest = { path = "../pest", version = "2.5.5", default-features = false }
+pest_meta = { path = "../meta", version = "2.5.5" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.4" }
-pest_derive = { path = "../derive", version = "2.5.4" }
+pest = { path = "../pest", version = "2.5.5" }
+pest_derive = { path = "../derive", version = "2.5.5" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.4" }
+pest = { path = "../pest", version = "2.5.5" }
 once_cell = "1.8.0"
 
 [build-dependencies]

--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -49,6 +49,13 @@ pub enum RuleType {
 }
 
 /// All possible rule expressions
+///
+/// # Warning: Semantic Versioning
+/// There may be non-breaking changes to the meta-grammar
+/// between minor versions. Those non-breaking changes, however,
+/// may translate into semver-breaking changes due to the additional variants
+/// propaged from the `Rule` enum. This is a known issue and will be fixed in the
+/// future (e.g. by increasing MSRV and non_exhaustive annotations).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expr {
     /// Matches an exact string, e.g. `"a"`

--- a/meta/src/grammar.pest
+++ b/meta/src/grammar.pest
@@ -7,6 +7,13 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 //! Pest meta-grammar
+//!
+//! # Warning: Semantic Versioning
+//! There may be non-breaking changes to the meta-grammar
+//! between minor versions. Those non-breaking changes, however,
+//! may translate into semver-breaking changes due to the additional variants
+//! added to the `Rule` enum. This is a known issue and will be fixed in the
+//! future (e.g. by increasing MSRV and non_exhaustive annotations).
 
 /// The top-level rule of a grammar.
 grammar_rules = _{ SOI ~ grammar_doc* ~ (grammar_rule)+ ~ EOI }

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -102,6 +102,13 @@ pub struct OptimizedRule {
 }
 
 /// The optimized version of the pest AST's `Expr`.
+///
+/// # Warning: Semantic Versioning
+/// There may be non-breaking changes to the meta-grammar
+/// between minor versions. Those non-breaking changes, however,
+/// may translate into semver-breaking changes due to the additional variants
+/// propaged from the `Rule` enum. This is a known issue and will be fixed in the
+/// future (e.g. by increasing MSRV and non_exhaustive annotations).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OptimizedExpr {
     /// Matches an exact string, e.g. `"a"`

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -21,9 +21,6 @@ std = ["ucd-trie/std", "thiserror"]
 pretty-print = ["serde", "serde_json"]
 # Enable const fn constructor for `PrecClimber`
 const_prec_climber = []
-# Enable faster `Position::line_col` calculation using SIMD
-# (note that this may have extra overhead for small inputs)
-fast-line-col = ["memchr", "bytecount"]
 
 [dependencies]
 ucd-trie = { version = "0.1.5", default-features = false }
@@ -31,4 +28,3 @@ serde = { version = "1.0.145", optional = true }
 serde_json = { version = "1.0.85", optional = true}
 thiserror = { version = "1.0.37", optional = true }
 memchr = { version = "2", optional = true }
-bytecount = { version = "0.6", optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,5 +14,5 @@ readme = "_README.md"
 rust-version = "1.56"
 
 [dependencies]
-pest = { path = "../pest", version = "2.5.4" }
-pest_meta = { path = "../meta", version = "2.5.4" }
+pest = { path = "../pest", version = "2.5.5" }
+pest_meta = { path = "../meta", version = "2.5.5" }


### PR DESCRIPTION
using line_col from pairs is recommended: https://github.com/pest-parser/pest/pull/785#issuecomment-1413604569 as it's faster or similar performance after the line-index patch