### PR TITLE
[RFC] support custom state and hooks

### DIFF
--- a/derive/examples/hook.pest
+++ b/derive/examples/hook.pest
@@ -1,0 +1,4 @@
+WHITESPACE   =  _{ " " | "\t" | NEWLINE }
+int          =  @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT+ | ASCII_DIGIT) }
+__HOOK_INT   =  _{ int }
+ints         =  { __HOOK_INT* }

--- a/derive/examples/hook.pest
+++ b/derive/examples/hook.pest
@@ -1,4 +1,5 @@
 WHITESPACE   =  _{ " " | "\t" | NEWLINE }
 int          =  @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT+ | ASCII_DIGIT) }
 __HOOK_INT   =  _{ int }
-ints         =  { __HOOK_INT* }
+ints         =  { SOI ~ __HOOK_INT* ~ EOI }
+ints2        =  { SOI ~ (__HOOK_INT ~ "yes" | int ~ "no")* ~ EOI }

--- a/derive/examples/hook.rs
+++ b/derive/examples/hook.rs
@@ -1,5 +1,5 @@
 mod parser {
-    use pest::Span;
+    use pest::{Span, StateCheckpoint};
     use pest_derive::Parser;
 
     #[derive(Parser)]
@@ -9,6 +9,16 @@ mod parser {
 
     #[derive(Default)]
     pub struct CustomState {}
+
+    impl StateCheckpoint for CustomState {
+        fn snapshot(&mut self) {}
+        fn clear_snapshot(&mut self) {}
+        fn restore(&mut self) {
+            unimplemented!(
+                "this state cannot restore -- please check your grammar to avoid restoring"
+            );
+        }
+    }
 
     impl Parser {
         fn hook__HOOK_INT<'a>(state: &mut CustomState, span: Span<'a>) -> bool {

--- a/derive/examples/hook.rs
+++ b/derive/examples/hook.rs
@@ -1,0 +1,20 @@
+mod parser {
+    use pest::Span;
+    use pest_derive::Parser;
+
+    #[derive(Parser)]
+    #[grammar = "../examples/hook.pest"]
+    #[custom_state(crate::parser::CustomState)]
+    pub struct Parser;
+
+    #[derive(Default)]
+    pub struct CustomState {}
+
+    impl Parser {
+        fn hook__HOOK_INT<'a>(state: &mut CustomState, span: Span<'a>) -> bool {
+            true
+        }
+    }
+}
+
+fn main() {}

--- a/derive/examples/hook.rs
+++ b/derive/examples/hook.rs
@@ -1,3 +1,5 @@
+use pest::StateParser;
+
 mod parser {
     use pest::{Span, StateCheckpoint};
     use pest_derive::Parser;
@@ -7,24 +9,93 @@ mod parser {
     #[custom_state(crate::parser::CustomState)]
     pub struct Parser;
 
-    #[derive(Default)]
-    pub struct CustomState {}
+    pub struct CustomState {
+        pub max_int_visited: usize,
+        is_snapshot_cleared: bool,
+    }
 
     impl StateCheckpoint for CustomState {
         fn snapshot(&mut self) {}
-        fn clear_snapshot(&mut self) {}
-        fn restore(&mut self) {
-            unimplemented!(
-                "this state cannot restore -- please check your grammar to avoid restoring"
-            );
+        fn clear_snapshot(&mut self) {
+            self.is_snapshot_cleared = true;
+        }
+        fn restore(&mut self) {}
+    }
+
+    impl CustomState {
+        pub fn create() -> Self {
+            Self {
+                max_int_visited: 0,
+                is_snapshot_cleared: true,
+            }
         }
     }
 
     impl Parser {
+        #[allow(non_snake_case)]
         fn hook__HOOK_INT<'a>(state: &mut CustomState, span: Span<'a>) -> bool {
-            true
+            if !state.is_snapshot_cleared {
+                println!("this state cannot operate with snapshot, please check your grammar to avoid hook in unexpected location",);
+                return false;
+            }
+            let val: usize = span.as_str().parse().unwrap();
+            println!("hook called with val={}", val);
+            if val >= state.max_int_visited {
+                state.is_snapshot_cleared = false;
+                state.max_int_visited = val;
+                true
+            } else {
+                false
+            }
         }
     }
 }
 
-fn main() {}
+fn main() {
+    // parser::Rule::ints parses a non-decreasing sequence of integers.
+
+    println!("parser::Rule::ints");
+
+    // should parse successfully.
+    let (state, _) = parser::Parser::parse_with_state(
+        parser::Rule::ints,
+        "1\n2\n3\n4\n",
+        parser::CustomState::create(),
+    )
+    .unwrap();
+    assert_eq!(state.max_int_visited, 4);
+
+    println!("parser::Rule::ints");
+
+    // custom state hook will reject this case
+    assert!(parser::Parser::parse_with_state(
+        parser::Rule::ints,
+        "1\n2\n2\n0\n",
+        parser::CustomState::create()
+    )
+    .is_err());
+
+    // parser::Rule::ints2 passes a non-decreasing sequence of integers to HOOK_INT, while allowing
+    // other numbers in the sequence.
+
+    println!("parser::Rule::ints2");
+
+    // should parse successfully.
+    let (state, _) = parser::Parser::parse_with_state(
+        parser::Rule::ints2,
+        "1 yes\n2 yes\n3 yes\n4 yes\n",
+        parser::CustomState::create(),
+    )
+    .unwrap();
+    assert_eq!(state.max_int_visited, 4);
+
+    println!("parser::Rule::ints2");
+
+    // custom state hook will still be called with val = 3, but it will be restored.
+    assert!(parser::Parser::parse_with_state(
+        parser::Rule::ints2,
+        "1 yes\n2 yes\n3 no\n4 yes\n",
+        parser::CustomState::create()
+    )
+    .is_err());
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -319,7 +319,7 @@ use proc_macro::TokenStream;
 
 /// The main method that's called by the proc macro
 /// (a wrapper around `pest_generator::derive_parser`)
-#[proc_macro_derive(Parser, attributes(grammar, grammar_inline))]
+#[proc_macro_derive(Parser, attributes(grammar, grammar_inline, custom_state))]
 pub fn derive_parser(input: TokenStream) -> TokenStream {
     pest_generator::derive_parser(input.into(), true).into()
 }

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -88,7 +88,7 @@ pub(crate) fn generate(
                     pub use self::visible::*;
                 }
 
-                ::pest::state(input, |state| {
+                ::pest::state_custom(input, |state| {
                     match rule {
                         #patterns
                     }

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -27,10 +27,17 @@ pub(crate) fn generate(
     defaults: Vec<&str>,
     doc_comment: &DocComment,
     include_grammar: bool,
+    custom_state: Option<TokenStream>,
 ) -> TokenStream {
     let uses_eoi = defaults.iter().any(|name| *name == "EOI");
 
-    let builtins = generate_builtin_rules();
+    let custom_state = if let Some(custom_state) = custom_state {
+        quote! { #custom_state }
+    } else {
+        quote! { () }
+    };
+
+    let builtins = generate_builtin_rules(custom_state.clone());
     let include_fix = if include_grammar {
         generate_include(&name, paths)
     } else {
@@ -38,9 +45,12 @@ pub(crate) fn generate(
     };
     let rule_enum = generate_enum(&rules, doc_comment, uses_eoi);
     let patterns = generate_patterns(&rules, uses_eoi);
-    let skip = generate_skip(&rules);
+    let skip = generate_skip(&rules, custom_state.clone());
 
-    let mut rules: Vec<_> = rules.into_iter().map(generate_rule).collect();
+    let mut rules: Vec<_> = rules
+        .into_iter()
+        .map(|rule| generate_rule(&name, custom_state.clone(), rule))
+        .collect();
     rules.extend(builtins.into_iter().filter_map(|(builtin, tokens)| {
         if defaults.contains(&builtin) {
             Some(tokens)
@@ -96,42 +106,75 @@ pub(crate) fn generate(
 
 // Note: All builtin rules should be validated as pest builtins in meta/src/validator.rs.
 // Some should also be keywords.
-fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
+fn generate_builtin_rules(custom_state: TokenStream) -> Vec<(&'static str, TokenStream)> {
     let mut builtins = Vec::new();
 
-    insert_builtin!(builtins, ANY, state.skip(1));
+    insert_builtin!(builtins, ANY, state.skip(1), custom_state);
     insert_builtin!(
         builtins,
         EOI,
-        state.rule(Rule::EOI, |state| state.end_of_input())
+        state.rule(Rule::EOI, |state| state.end_of_input()),
+        custom_state
     );
-    insert_builtin!(builtins, SOI, state.start_of_input());
-    insert_builtin!(builtins, PEEK, state.stack_peek());
-    insert_builtin!(builtins, PEEK_ALL, state.stack_match_peek());
-    insert_builtin!(builtins, POP, state.stack_pop());
-    insert_builtin!(builtins, POP_ALL, state.stack_match_pop());
-    insert_builtin!(builtins, DROP, state.stack_drop());
+    insert_builtin!(builtins, SOI, state.start_of_input(), custom_state);
+    insert_builtin!(builtins, PEEK, state.stack_peek(), custom_state);
+    insert_builtin!(builtins, PEEK_ALL, state.stack_match_peek(), custom_state);
+    insert_builtin!(builtins, POP, state.stack_pop(), custom_state);
+    insert_builtin!(builtins, POP_ALL, state.stack_match_pop(), custom_state);
+    insert_builtin!(builtins, DROP, state.stack_drop(), custom_state);
 
-    insert_builtin!(builtins, ASCII_DIGIT, state.match_range('0'..'9'));
-    insert_builtin!(builtins, ASCII_NONZERO_DIGIT, state.match_range('1'..'9'));
-    insert_builtin!(builtins, ASCII_BIN_DIGIT, state.match_range('0'..'1'));
-    insert_builtin!(builtins, ASCII_OCT_DIGIT, state.match_range('0'..'7'));
+    insert_builtin!(
+        builtins,
+        ASCII_DIGIT,
+        state.match_range('0'..'9'),
+        custom_state
+    );
+    insert_builtin!(
+        builtins,
+        ASCII_NONZERO_DIGIT,
+        state.match_range('1'..'9'),
+        custom_state
+    );
+    insert_builtin!(
+        builtins,
+        ASCII_BIN_DIGIT,
+        state.match_range('0'..'1'),
+        custom_state
+    );
+    insert_builtin!(
+        builtins,
+        ASCII_OCT_DIGIT,
+        state.match_range('0'..'7'),
+        custom_state
+    );
     insert_builtin!(
         builtins,
         ASCII_HEX_DIGIT,
         state
             .match_range('0'..'9')
             .or_else(|state| state.match_range('a'..'f'))
-            .or_else(|state| state.match_range('A'..'F'))
+            .or_else(|state| state.match_range('A'..'F')),
+        custom_state
     );
-    insert_builtin!(builtins, ASCII_ALPHA_LOWER, state.match_range('a'..'z'));
-    insert_builtin!(builtins, ASCII_ALPHA_UPPER, state.match_range('A'..'Z'));
+    insert_builtin!(
+        builtins,
+        ASCII_ALPHA_LOWER,
+        state.match_range('a'..'z'),
+        custom_state
+    );
+    insert_builtin!(
+        builtins,
+        ASCII_ALPHA_UPPER,
+        state.match_range('A'..'Z'),
+        custom_state
+    );
     insert_builtin!(
         builtins,
         ASCII_ALPHA,
         state
             .match_range('a'..'z')
-            .or_else(|state| state.match_range('A'..'Z'))
+            .or_else(|state| state.match_range('A'..'Z')),
+        custom_state
     );
     insert_builtin!(
         builtins,
@@ -139,16 +182,23 @@ fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
         state
             .match_range('a'..'z')
             .or_else(|state| state.match_range('A'..'Z'))
-            .or_else(|state| state.match_range('0'..'9'))
+            .or_else(|state| state.match_range('0'..'9')),
+        custom_state
     );
-    insert_builtin!(builtins, ASCII, state.match_range('\x00'..'\x7f'));
+    insert_builtin!(
+        builtins,
+        ASCII,
+        state.match_range('\x00'..'\x7f'),
+        custom_state
+    );
     insert_builtin!(
         builtins,
         NEWLINE,
         state
             .match_string("\n")
             .or_else(|state| state.match_string("\r\n"))
-            .or_else(|state| state.match_string("\r"))
+            .or_else(|state| state.match_string("\r")),
+        custom_state
     );
 
     let box_ty = box_type();
@@ -159,7 +209,7 @@ fn generate_builtin_rules() -> Vec<(&'static str, TokenStream)> {
         builtins.push((property, quote! {
             #[inline]
             #[allow(dead_code, non_snake_case, unused_variables)]
-            fn #property_ident(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            fn #property_ident(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 state.match_char_by(::pest::unicode::#property_ident)
             }
         }));
@@ -258,7 +308,31 @@ fn generate_patterns(rules: &[OptimizedRule], uses_eoi: bool) -> TokenStream {
     }
 }
 
-fn generate_rule(rule: OptimizedRule) -> TokenStream {
+fn generate_expr_hooked(parser_name: &Ident, name: Ident, expr: OptimizedExpr) -> TokenStream {
+    if let OptimizedExpr::Ident(ident) = expr {
+        let name = format_ident!("r#hook{}", name);
+        let ident = format_ident!("r#{}", ident);
+        quote! {
+          let start = *state.position();
+          let mut state = self::#ident(state)?;
+          let end = *state.position();
+          let span = start.span(&end);
+          if super::super::#parser_name::#name(state.state_mut(), span) {
+            Ok(state)
+          } else {
+            Err(state)
+          }
+        }
+    } else {
+        unreachable!("__HOOK can be only applied in grammars with a single ident");
+    }
+}
+
+fn generate_rule(
+    parser_name: &Ident,
+    custom_state: TokenStream,
+    rule: OptimizedRule,
+) -> TokenStream {
     let name = format_ident!("r#{}", rule.name);
     let expr = if rule.ty == RuleType::Atomic || rule.ty == RuleType::CompoundAtomic {
         generate_expr_atomic(rule.expr)
@@ -270,6 +344,8 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
                 #atomic
             })
         }
+    } else if rule.name.starts_with("__HOOK") {
+        generate_expr_hooked(parser_name, name.clone(), rule.expr)
     } else {
         generate_expr(rule.expr)
     };
@@ -280,7 +356,7 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
         RuleType::Normal => quote! {
             #[inline]
             #[allow(non_snake_case, unused_variables)]
-            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 state.rule(Rule::#name, |state| {
                     #expr
                 })
@@ -289,14 +365,14 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
         RuleType::Silent => quote! {
             #[inline]
             #[allow(non_snake_case, unused_variables)]
-            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 #expr
             }
         },
         RuleType::Atomic => quote! {
             #[inline]
             #[allow(non_snake_case, unused_variables)]
-            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 state.rule(Rule::#name, |state| {
                     state.atomic(::pest::Atomicity::Atomic, |state| {
                         #expr
@@ -307,7 +383,7 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
         RuleType::CompoundAtomic => quote! {
             #[inline]
             #[allow(non_snake_case, unused_variables)]
-            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 state.atomic(::pest::Atomicity::CompoundAtomic, |state| {
                     state.rule(Rule::#name, |state| {
                         #expr
@@ -318,7 +394,7 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
         RuleType::NonAtomic => quote! {
             #[inline]
             #[allow(non_snake_case, unused_variables)]
-            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule>>> {
+            pub fn #name(state: #box_ty<::pest::ParserState<'_, Rule, #custom_state>>) -> ::pest::ParseResult<#box_ty<::pest::ParserState<'_, Rule, #custom_state>>> {
                 state.atomic(::pest::Atomicity::NonAtomic, |state| {
                     state.rule(Rule::#name, |state| {
                         #expr
@@ -329,19 +405,20 @@ fn generate_rule(rule: OptimizedRule) -> TokenStream {
     }
 }
 
-fn generate_skip(rules: &[OptimizedRule]) -> TokenStream {
+fn generate_skip(rules: &[OptimizedRule], custom_state: TokenStream) -> TokenStream {
     let whitespace = rules.iter().any(|rule| rule.name == "WHITESPACE");
     let comment = rules.iter().any(|rule| rule.name == "COMMENT");
 
     match (whitespace, comment) {
-        (false, false) => generate_rule!(skip, Ok(state)),
+        (false, false) => generate_rule!(skip, Ok(state), custom_state),
         (true, false) => generate_rule!(
             skip,
             if state.atomicity() == ::pest::Atomicity::NonAtomic {
                 state.repeat(|state| super::visible::WHITESPACE(state))
             } else {
                 Ok(state)
-            }
+            },
+            custom_state
         ),
         (false, true) => generate_rule!(
             skip,
@@ -349,7 +426,8 @@ fn generate_skip(rules: &[OptimizedRule]) -> TokenStream {
                 state.repeat(|state| super::visible::COMMENT(state))
             } else {
                 Ok(state)
-            }
+            },
+            custom_state
         ),
         (true, true) => generate_rule!(
             skip,
@@ -369,7 +447,8 @@ fn generate_skip(rules: &[OptimizedRule]) -> TokenStream {
                 })
             } else {
                 Ok(state)
-            }
+            },
+            custom_state
         ),
     }
 }
@@ -1035,7 +1114,7 @@ mod tests {
         let test_path = current_dir.join("test.pest").to_str().unwrap().to_string();
 
         assert_eq!(
-            generate(name, &generics, vec![PathBuf::from("base.pest"), PathBuf::from("test.pest")], rules, defaults, doc_comment, true).to_string(),
+            generate(name, &generics, vec![PathBuf::from("base.pest"), PathBuf::from("test.pest")], rules, defaults, doc_comment, true, None).to_string(),
             quote! {
                 #[allow(non_upper_case_globals)]
                 const _PEST_GRAMMAR_MyParser: [&'static str; 2usize] = [include_str!(#base_path), include_str!(#test_path)];

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -65,12 +65,13 @@ pub(crate) fn generate(
 
     let parser_impl = quote! {
         #[allow(clippy::all)]
-        impl #impl_generics ::pest::Parser<Rule> for #name #ty_generics #where_clause {
-            fn parse<'i>(
+        impl #impl_generics ::pest::StateParser<Rule, #custom_state> for #name #ty_generics #where_clause {
+            fn parse_with_state<'i>(
                 rule: Rule,
-                input: &'i str
+                input: &'i str,
+                state: #custom_state
             ) -> #result<
-                ::pest::iterators::Pairs<'i, Rule>,
+                (#custom_state, ::pest::iterators::Pairs<'i, Rule>),
                 ::pest::error::Error<Rule>
             > {
                 mod rules {
@@ -92,7 +93,7 @@ pub(crate) fn generate(
                     match rule {
                         #patterns
                     }
-                })
+                }, state)
             }
         }
     };
@@ -1129,7 +1130,7 @@ mod tests {
                 }
 
                 #[allow(clippy::all)]
-                impl ::pest::Parser<Rule> for MyParser {
+                impl ::pest::StateParser<Rule, #custom_state> for MyParser {
                     fn parse<'i>(
                         rule: Rule,
                         input: &'i str

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -192,7 +192,7 @@ fn get_attribute_custom_state(attr: &Attribute) -> TokenStream {
     match attr.parse_meta() {
         Ok(Meta::List(list)) => match list.nested.first() {
             Some(x) => {
-                return x.to_token_stream();
+                x.to_token_stream()
             }
             _ => panic!(),
         },

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -28,7 +28,6 @@ use std::path::Path;
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use quote::__private::ext::RepToTokensExt;
 use syn::{Attribute, DeriveInput, Generics, Ident, Lit, Meta};
 
 #[macro_use]

--- a/generator/src/macros.rs
+++ b/generator/src/macros.rs
@@ -9,7 +9,10 @@
 
 macro_rules! insert_builtin {
     ($builtin: expr, $name: ident, $pattern: expr, $custom_state: ident) => {
-        $builtin.push((stringify!($name), generate_rule!($name, $pattern, $custom_state)));
+        $builtin.push((
+            stringify!($name),
+            generate_rule!($name, $pattern, $custom_state),
+        ));
     };
 }
 

--- a/generator/src/macros.rs
+++ b/generator/src/macros.rs
@@ -8,18 +8,18 @@
 // modified, or distributed except according to those terms.
 
 macro_rules! insert_builtin {
-    ($builtin: expr, $name: ident, $pattern: expr) => {
-        $builtin.push((stringify!($name), generate_rule!($name, $pattern)));
+    ($builtin: expr, $name: ident, $pattern: expr, $custom_state: ident) => {
+        $builtin.push((stringify!($name), generate_rule!($name, $pattern, $custom_state)));
     };
 }
 
 #[cfg(feature = "std")]
 macro_rules! generate_rule {
-    ($name: ident, $pattern: expr) => {
+    ($name: ident, $pattern: expr, $custom_state: ident) => {
         quote! {
             #[inline]
             #[allow(dead_code, non_snake_case, unused_variables)]
-            pub fn $name(state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>) -> ::pest::ParseResult<::std::boxed::Box<::pest::ParserState<'_, Rule>>> {
+            pub fn $name(state: ::std::boxed::Box<::pest::ParserState<'_, Rule, #$custom_state>>) -> ::pest::ParseResult<::std::boxed::Box<::pest::ParserState<'_, Rule, #$custom_state>>> {
                 $pattern
             }
         }

--- a/meta/src/optimizer/restorer.rs
+++ b/meta/src/optimizer/restorer.rs
@@ -62,6 +62,7 @@ fn child_modifies_state(
 ) -> bool {
     expr.iter_top_down().any(|expr| match expr {
         OptimizedExpr::Push(_) => true,
+        OptimizedExpr::Ident(ref name) if name.starts_with("__HOOK") => true,
         OptimizedExpr::Ident(ref name) if name == "DROP" => true,
         OptimizedExpr::Ident(ref name) if name == "POP" => true,
         OptimizedExpr::Ident(ref name) => match cache.get(name).cloned() {

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -334,7 +334,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use crate::parser::Parser;
+pub use crate::parser::{Parser, StateParser};
 pub use crate::parser_state::{
     set_call_limit, state, state_custom, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
     StateCheckpoint,

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -336,7 +336,8 @@ extern crate std;
 
 pub use crate::parser::Parser;
 pub use crate::parser_state::{
-    set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
+    set_call_limit, state, state_custom, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
+    StateCheckpoint,
 };
 pub use crate::position::Position;
 pub use crate::span::{Lines, LinesSpan, Span};


### PR DESCRIPTION
# Guided-Level Explanation

This PR adds a "context" for parsing with pest (for one of my course projects where I'm using pest...). Now users can parse with a custom state as a context. One example is the following grammar, where we want `ints` to parse a sequence of non-decrementing numbers.

```
WHITESPACE   =  _{ " " | "\t" | NEWLINE }
int          =  @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT+ | ASCII_DIGIT) }
__HOOK_INT   =  _{ int }
ints         =  { SOI ~ __HOOK_INT* ~ EOI }
```

For all terms beginning with `__HOOK`, the generator will call user-defined hooks before deciding whether to parse.

```
    #[derive(Parser)]
    #[grammar = "../examples/hook.pest"]
    #[custom_state(crate::parser::CustomState)]
    pub struct Parser;

    pub struct CustomState {
        pub max_int_visited: usize,
    }

    impl Parser {
        #[allow(non_snake_case)]
        fn hook__HOOK_INT<'a>(state: &mut CustomState, span: Span<'a>) -> bool {
            let val: usize = span.as_str().parse().unwrap();
            if val >= state.max_int_visited {
                state.max_int_visited = val;
                true
            } else {
                false
            }
        }
    }
```

The state will need to support snapshot / recovery so that the hook can be placed anywhere. But users can also opt-out recovery and modify their grammar to avoid this situation. Examples in `hook.rs`. and `hook.pest`.

# Implementation-Level Explanation

`ParseState` now contains a field for storing custom state. It is by-default set to `()`.

```
pub struct ParserState<'i, R: RuleType, S = ()>
where
    S: StateCheckpoint,
```

We now have a new parser trait called `StateParser`, where we accept a state + input and return rules + state.

```
/// A trait with a single method that parses strings.
pub trait StateParser<R: RuleType, S: StateCheckpoint> {
    /// Parses a `&str` starting from `rule`.
    #[allow(clippy::perf)]
    fn parse_with_state(rule: R, input: &str, state: S) -> Result<(S, Pairs<'_, R>), Error<R>>;
}
```

The generator crate is refactored to implement custom state generic type for all traits. Some functions also have new signatures in order to accept custom state.

This PR is a demo and I'm open to suggestions / changes to this new feature. If it doesn't work I can also maintain it in my own fork. Thanks for review!