### PR TITLE
Fixup lifetimes of PrattParser

### DIFF
--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -235,10 +235,10 @@ impl<R: RuleType> PrattParser<R> {
     }
 
     /// Maps primary expressions with a closure `primary`.
-    pub fn map_primary<'pratt, 'i, X, T>(
+    pub fn map_primary<'pratt, 'a, 'i, X, T>(
         &'pratt self,
         primary: X,
-    ) -> PrattParserMap<'pratt, 'i, R, X, T>
+    ) -> PrattParserMap<'pratt, 'a, 'i, R, X, T>
     where
         X: FnMut(Pair<'i, R>) -> T,
         R: 'pratt,
@@ -254,29 +254,29 @@ impl<R: RuleType> PrattParser<R> {
     }
 }
 
-type PrefixFn<'i, R, T> = Box<dyn FnMut(Pair<'i, R>, T) -> T + 'i>;
-type PostfixFn<'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>) -> T + 'i>;
-type InfixFn<'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>, T) -> T + 'i>;
+type PrefixFn<'a, 'i, R, T> = Box<dyn FnMut(Pair<'i, R>, T) -> T + 'a>;
+type PostfixFn<'a, 'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>) -> T + 'a>;
+type InfixFn<'a, 'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>, T) -> T + 'a>;
 
 /// Product of calling [`map_primary`] on [`PrattParser`], defines how expressions should
 /// be mapped.
 ///
 /// [`map_primary`]: struct.PrattParser.html#method.map_primary
 /// [`PrattParser`]: struct.PrattParser.html
-pub struct PrattParserMap<'pratt, 'i, R, F, T>
+pub struct PrattParserMap<'pratt, 'a, 'i, R, F, T>
 where
     R: RuleType,
     F: FnMut(Pair<'i, R>) -> T,
 {
     pratt: &'pratt PrattParser<R>,
     primary: F,
-    prefix: Option<PrefixFn<'i, R, T>>,
-    postfix: Option<PostfixFn<'i, R, T>>,
-    infix: Option<InfixFn<'i, R, T>>,
+    prefix: Option<PrefixFn<'a, 'i, R, T>>,
+    postfix: Option<PostfixFn<'a, 'i, R, T>>,
+    infix: Option<InfixFn<'a, 'i, R, T>>,
     phantom: PhantomData<T>,
 }
 
-impl<'pratt, 'i, R, F, T> PrattParserMap<'pratt, 'i, R, F, T>
+impl<'pratt, 'a, 'i, R, F, T> PrattParserMap<'pratt, 'a, 'i, R, F, T>
 where
     R: RuleType + 'pratt,
     F: FnMut(Pair<'i, R>) -> T,
@@ -284,7 +284,7 @@ where
     /// Maps prefix operators with closure `prefix`.
     pub fn map_prefix<X>(mut self, prefix: X) -> Self
     where
-        X: FnMut(Pair<'i, R>, T) -> T + 'i,
+        X: FnMut(Pair<'i, R>, T) -> T + 'a,
     {
         self.prefix = Some(Box::new(prefix));
         self
@@ -293,7 +293,7 @@ where
     /// Maps postfix operators with closure `postfix`.
     pub fn map_postfix<X>(mut self, postfix: X) -> Self
     where
-        X: FnMut(T, Pair<'i, R>) -> T + 'i,
+        X: FnMut(T, Pair<'i, R>) -> T + 'a,
     {
         self.postfix = Some(Box::new(postfix));
         self
@@ -302,7 +302,7 @@ where
     /// Maps infix operators with a closure `infix`.
     pub fn map_infix<X>(mut self, infix: X) -> Self
     where
-        X: FnMut(T, Pair<'i, R>, T) -> T + 'i,
+        X: FnMut(T, Pair<'i, R>, T) -> T + 'a,
     {
         self.infix = Some(Box::new(infix));
         self


### PR DESCRIPTION
Currently the typings require the passed in callbacks to have the lifetime `'i`, and thus any values it reference must also have the same lifetime. If these callbacks return a value with lifetime `'i`, the borrow checker incorrectly assumes that those referenced values must also outlive the return value.

For example this code:
```rust
fn test_pratt<'a>(pairs: Pairs<'a, Rule>, message: &str) -> &'a str {
    PRATT_PARSER
        .map_primary(|pair| {
            // println!("{message}");
            pair.as_str()
        })
        .map_infix(|lhs, pair, rhs| {
            println!("{message}");
            pair.as_str()
        })
        .parse(pairs)
}
```
fails to compile with this error:
```
error[E0621]: explicit lifetime required in the type of `message`
   --> src/compiler/expression.rs:285:5
    |
284 |   fn test_pratt<'a>(pairs: Pairs<'a, Rule>, message: &str) -> &'a str {
    |                                                      ---- help: add explicit lifetime `'a` to the type of `message`: `&'a str`
285 | /     PRATT_PARSER
286 | |         .map_primary(|pair| {
287 | |             // println!("{message}");
288 | |             pair.as_str()
...   |
293 | |         })
294 | |         .parse(pairs)
    | |_____________________^ lifetime `'a` required
```

This is a small PR that adds a new lifetime to `PrattParserMap` so the callbacks can have a separate lifetime. This fixes the above issue.