### PR TITLE
Update syn to v2

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -22,4 +22,4 @@ pest = { path = "../pest", version = "2.5.6", default-features = false }
 pest_meta = { path = "../meta", version = "2.5.6" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = "2.0"


### PR DESCRIPTION
Just fixes up the breakages from the `syn` update

It seems like the only thing that needed changing was from `meta` becoming a field of `Attribute` with nested meta parsing getting moved to a separate method entirely