### PR TITLE
Implement `ExactSizeIterator` for `Pair` iterators

### DIFF
--- a/grammars/benches/json.rs
+++ b/grammars/benches/json.rs
@@ -88,6 +88,10 @@ fn bench_line_col(c: &mut Criterion) {
 // pairs nested iter (with LineIndex)   time:   [14.716 µs 14.822 µs 14.964 µs]
 // pairs flatten iter (v2.5.2)          time:   [1.1230 µs 1.1309 µs 1.1428 µs]
 // pairs flatten iter (with LineIndex)  time:   [5.4637 µs 5.6061 µs 5.7886 µs]
+// pairs nested collect (v2.5.7)        time:   [8.4609 µs 8.4644 µs 8.4680 µs]
+// pairs nested collect (ExactSize)     time:   [7.9492 µs 7.9604 µs 7.9751 µs]
+// pairs flatten collect (v2.5.7)       time:   [11.471 µs 11.475 µs 11.480 µs]
+// pairs flatten collect (ExactSize)    time:   [11.058 µs 11.062 µs 11.066 µs]
 fn bench_pairs_iter(c: &mut Criterion) {
     let data = include_str!("data.json");
 
@@ -109,6 +113,22 @@ fn bench_pairs_iter(c: &mut Criterion) {
             for _pair in pairs.clone().flatten() {
                 // do nothing
             }
+        });
+    });
+
+    c.bench_function("pairs nested collect", |b| {
+        let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, data).unwrap();
+
+        b.iter(move || {
+            let _pairs = pairs.clone().collect::<Vec<_>>();
+        });
+    });
+
+    c.bench_function("pairs flatten collect", |b| {
+        let pairs = autocorrect::JsonParser::parse(autocorrect::Rule::item, data).unwrap();
+
+        b.iter(move || {
+            let _pairs = pairs.clone().flatten().collect::<Vec<_>>();
         });
     });
 }

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -104,17 +104,8 @@ impl<'i, R: RuleType> FlatPairs<'i, R> {
 
 impl<'i, R: RuleType> ExactSizeIterator for FlatPairs<'i, R> {
     fn len(&self) -> usize {
-        let mut start = self.start;
-        let mut count = 0;
-        while start < self.end {
-            start += 1;
-            while start < self.end && !self.is_start(start) {
-                start += 1;
-            }
-
-            count += 1;
-        }
-        count
+        // Tokens len is exactly twice as flatten pairs len
+        (self.end - self.start) >> 1
     }
 }
 
@@ -239,6 +230,9 @@ mod tests {
     #[test]
     fn exact_size_iter_for_pairs() {
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();
+        assert_eq!(pairs.len(), pairs.count());
+
+        let pairs = AbcParser::parse(Rule::a, "我很漂亮efgh").unwrap().flatten();
         assert_eq!(pairs.len(), pairs.count());
 
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -239,19 +239,15 @@ mod tests {
     #[test]
     fn exact_size_iter_for_pairs() {
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();
-        let pairs_len = pairs.len();
-        let pairs = pairs.collect::<Vec<_>>();
-        assert_eq!(pairs.len(), pairs_len);
+        assert_eq!(pairs.len(), pairs.count());
 
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();
         let pairs = pairs.rev();
-        let pairs_len = pairs.len();
-        let pairs = pairs.collect::<Vec<_>>();
-        assert_eq!(pairs.len(), pairs_len);
+        assert_eq!(pairs.len(), pairs.count());
 
         let mut pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();
         let pairs_len = pairs.len();
         let _ = pairs.next().unwrap();
-        assert_eq!(pairs.len() + 1, pairs_len);
+        assert_eq!(pairs.count() + 1, pairs_len);
     }
 }

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -243,7 +243,8 @@ mod tests {
         let pairs = pairs.collect::<Vec<_>>();
         assert_eq!(pairs.len(), pairs_len);
 
-        let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten().rev();
+        let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().flatten();
+        let pairs = pairs.rev();
         let pairs_len = pairs.len();
         let pairs = pairs.collect::<Vec<_>>();
         assert_eq!(pairs.len(), pairs_len);

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -349,8 +349,6 @@ impl<'i, R: RuleType> ::serde::Serialize for Pairs<'i, R> {
 
 #[cfg(test)]
 mod tests {
-    use crate::iterators::Pair;
-
     use super::super::super::macros::tests::*;
     use super::super::super::Parser;
     use alloc::borrow::ToOwned;
@@ -507,18 +505,14 @@ mod tests {
     #[test]
     fn exact_size_iter_for_pairs() {
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap();
-        let pairs_len = pairs.len();
-        let pairs = pairs.collect::<Vec<Pair<'_, Rule>>>();
-        assert_eq!(pairs.len(), pairs_len);
+        assert_eq!(pairs.len(), pairs.count());
 
         let pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap().rev();
-        let pairs_len = pairs.len();
-        let pairs = pairs.collect::<Vec<Pair<'_, Rule>>>();
-        assert_eq!(pairs.len(), pairs_len);
+        assert_eq!(pairs.len(), pairs.count());
 
         let mut pairs = AbcParser::parse(Rule::a, "abc\nefgh").unwrap();
         let pairs_len = pairs.len();
         let _ = pairs.next().unwrap();
-        assert_eq!(pairs.len() + 1, pairs_len);
+        assert_eq!(pairs.count() + 1, pairs_len);
     }
 }

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -160,6 +160,9 @@ mod tests {
         let tokens = AbcParser::parse(Rule::a, "abcde").unwrap().tokens();
         assert_eq!(tokens.len(), tokens.count());
 
+        let tokens = AbcParser::parse(Rule::a, "我很漂亮e").unwrap().tokens();
+        assert_eq!(tokens.len(), tokens.count());
+
         let tokens = AbcParser::parse(Rule::a, "abcde").unwrap().tokens().rev();
         assert_eq!(tokens.len(), tokens.count());
 

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -158,18 +158,14 @@ mod tests {
     #[test]
     fn exact_size_iter_for_tokens() {
         let tokens = AbcParser::parse(Rule::a, "abcde").unwrap().tokens();
-        let tokens_len = tokens.len();
-        let tokens = tokens.collect::<Vec<Token<'_, Rule>>>();
-        assert_eq!(tokens.len(), tokens_len);
+        assert_eq!(tokens.len(), tokens.count());
 
         let tokens = AbcParser::parse(Rule::a, "abcde").unwrap().tokens().rev();
-        let tokens_len = tokens.len();
-        let tokens = tokens.collect::<Vec<Token<'_, Rule>>>();
-        assert_eq!(tokens.len(), tokens_len);
+        assert_eq!(tokens.len(), tokens.count());
 
         let mut tokens = AbcParser::parse(Rule::a, "abcde").unwrap().tokens();
         let tokens_len = tokens.len();
         let _ = tokens.next().unwrap();
-        assert_eq!(tokens.len() + 1, tokens_len);
+        assert_eq!(tokens.count() + 1, tokens_len);
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -489,13 +489,11 @@ mod tests {
         let span = Span::new(input, 1, 7).unwrap();
 
         let lines_span = span.lines_span();
-        let lines_len = lines_span.len();
-        let lines_span = lines_span.collect::<Vec<_>>();
-        assert_eq!(lines_span.len(), lines_len);
+        assert_eq!(lines_span.len(), lines_span.count());
 
         let mut lines_span = span.lines_span();
         let lines_len = lines_span.len();
         let _ = lines_span.next().unwrap();
-        assert_eq!(lines_span.len() + 1, lines_len);
+        assert_eq!(lines_span.count() + 1, lines_len);
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -298,26 +298,6 @@ pub struct LinesSpan<'i> {
     pos: usize,
 }
 
-impl<'i> ExactSizeIterator for LinesSpan<'i> {
-    fn len(&self) -> usize {
-        let mut self_pos = self.pos;
-        let mut count = 0;
-        while self_pos < self.span.end {
-            let pos = match position::Position::new(self.span.input, self_pos) {
-                Some(pos) => pos,
-                None => break,
-            };
-            if pos.at_end() {
-                break;
-            }
-
-            self_pos = pos.find_line_end();
-            count += 1;
-        }
-        count
-    }
-}
-
 impl<'i> Iterator for LinesSpan<'i> {
     type Item = Span<'i>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -334,11 +314,6 @@ impl<'i> Iterator for LinesSpan<'i> {
 
         Span::new(self.span.input, line_start, self.pos)
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = <Self as ExactSizeIterator>::len(self);
-        (len, Some(len))
-    }
 }
 
 /// Line iterator for Spans, created by [`Span::lines()`].
@@ -350,20 +325,10 @@ pub struct Lines<'i> {
     inner: LinesSpan<'i>,
 }
 
-impl<'i> ExactSizeIterator for Lines<'i> {
-    fn len(&self) -> usize {
-        self.inner.len()
-    }
-}
-
 impl<'i> Iterator for Lines<'i> {
     type Item = &'i str;
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|span| span.as_str())
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
     }
 }
 
@@ -481,19 +446,5 @@ mod tests {
                 .collect::<Vec<_>>(),
             lines
         );
-    }
-
-    #[test]
-    fn exact_size_iter_for_lines_span() {
-        let input = "abc\ndef\nghi";
-        let span = Span::new(input, 1, 7).unwrap();
-
-        let lines_span = span.lines_span();
-        assert_eq!(lines_span.len(), lines_span.count());
-
-        let mut lines_span = span.lines_span();
-        let lines_len = lines_span.len();
-        let _ = lines_span.next().unwrap();
-        assert_eq!(lines_span.count() + 1, lines_len);
     }
 }


### PR DESCRIPTION
PR adds impl `ExactSizeIterator` and `size_hint` accordingly for `Pairs`, `Tokens`, `FlatPairs` and `LinesSpan`. This can hint rust compiler to allocate proper memory amount while collecting to vector or similar containers