### PR TITLE
Removed TODO about removed box syntax

### DIFF
--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -116,7 +116,6 @@ impl Expr {
             let expr = f(expr);
 
             match expr {
-                // TODO: Use box syntax when it gets stabilized.
                 Expr::PosPred(expr) => {
                     let mapped = Box::new(map_internal(*expr, f));
                     Expr::PosPred(mapped)
@@ -189,7 +188,6 @@ impl Expr {
         {
             let mapped = match expr {
                 Expr::PosPred(expr) => {
-                    // TODO: Use box syntax when it gets stabilized.
                     let mapped = Box::new(map_internal(*expr, f));
                     Expr::PosPred(mapped)
                 }

--- a/meta/src/optimizer/concatenator.rs
+++ b/meta/src/optimizer/concatenator.rs
@@ -16,7 +16,6 @@ pub fn concatenate(rule: Rule) -> Rule {
         ty,
         expr: expr.map_bottom_up(|expr| {
             if ty == RuleType::Atomic {
-                // TODO: Use box syntax when it gets stabilized.
                 match expr {
                     Expr::Seq(lhs, rhs) => match (*lhs, *rhs) {
                         (Expr::Str(lhs), Expr::Str(rhs)) => Expr::Str(lhs + &rhs),

--- a/meta/src/optimizer/factorizer.rs
+++ b/meta/src/optimizer/factorizer.rs
@@ -15,7 +15,6 @@ pub fn factor(rule: Rule) -> Rule {
         name,
         ty,
         expr: expr.map_top_down(|expr| {
-            // TODO: Use box syntax when it gets stabilized.
             match expr {
                 Expr::Choice(lhs, rhs) => match (*lhs, *rhs) {
                     (Expr::Seq(l1, r1), Expr::Seq(l2, r2)) => {

--- a/meta/src/optimizer/lister.rs
+++ b/meta/src/optimizer/lister.rs
@@ -15,7 +15,6 @@ pub fn list(rule: Rule) -> Rule {
         name,
         ty,
         expr: expr.map_bottom_up(|expr| {
-            // TODO: Use box syntax when it gets stabilized.
             match expr {
                 Expr::Seq(l, r) => match *l {
                     Expr::Rep(l) => {

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -162,7 +162,6 @@ impl OptimizedExpr {
             let expr = f(expr);
 
             match expr {
-                // TODO: Use box syntax when it gets stabilized.
                 OptimizedExpr::PosPred(expr) => {
                     let mapped = Box::new(map_internal(*expr, f));
                     OptimizedExpr::PosPred(mapped)
@@ -211,7 +210,6 @@ impl OptimizedExpr {
         {
             let mapped = match expr {
                 OptimizedExpr::PosPred(expr) => {
-                    // TODO: Use box syntax when it gets stabilized.
                     let mapped = Box::new(map_internal(*expr, f));
                     OptimizedExpr::PosPred(mapped)
                 }

--- a/meta/src/optimizer/rotater.rs
+++ b/meta/src/optimizer/rotater.rs
@@ -12,7 +12,6 @@ use crate::ast::*;
 pub fn rotate(rule: Rule) -> Rule {
     fn rotate_internal(expr: Expr) -> Expr {
         match expr {
-            // TODO: Use box syntax when it gets stabilized.
             Expr::Seq(lhs, rhs) => {
                 let lhs = *lhs;
                 match lhs {

--- a/meta/src/optimizer/skipper.rs
+++ b/meta/src/optimizer/skipper.rs
@@ -34,7 +34,6 @@ pub fn skip(rule: Rule) -> Rule {
         ty,
         expr: if ty == RuleType::Atomic {
             expr.map_top_down(|expr| {
-                // TODO: Use box syntax when it gets stabilized.
                 if let Expr::Rep(expr) = expr.clone() {
                     if let Expr::Seq(lhs, rhs) = *expr {
                         if let (Expr::NegPred(expr), Expr::Ident(ident)) = (*lhs, *rhs) {

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -71,7 +71,6 @@ impl<'i> ParserNode<'i> {
             }
 
             match node.expr {
-                // TODO: Use box syntax when it gets stabilized.
                 ParserExpr::PosPred(node) => {
                     filter_internal(*node, f, result);
                 }


### PR DESCRIPTION
I removed the multiple TODO comments about Rust's box syntax, because it has been removed according to rust-lang/rust/pull/108471