### PR TITLE
derive/examples: add a help menu grammar and parser

### DIFF
--- a/derive/examples/help-menu.pest
+++ b/derive/examples/help-menu.pest
@@ -1,27 +1,27 @@
-WHITESPACE    = _{ " " }
+WHITESPACE = _{ " " }
 
-WordAtom  = ! { ( ASCII_ALPHANUMERIC | "_" | "-" ) + }
-WordOne   = { WordAtom }
-WordGroup = { WordAtom ~ ( " " ~ WordAtom ) * }
-
-ArgumentAtom = ! { ( ASCII_ALPHANUMERIC | "_" | "-" ) + }
-ArgumentRequiredChoiceOne = { "<" ~ ArgumentAtom ~ ">" }
-ArgumentOptionalChoiceOne = { "[" ~ ArgumentAtom ~ "]" }
-ArgumentChoiceOne = { ArgumentRequiredChoiceOne
-                      | ArgumentOptionalChoiceOne }
+Rew       = ! { ( ASCII_DIGIT | ASCII_ALPHA_UPPER | "_" | "-" ) + }
+Lit       = ! { ( ASCII_ALPHANUMERIC              | "_" | "-" ) + }
+Word      = _ { Rew | Lit }
+WordGroup = _ { Word ~ ( " " ~ Word ) * }
 
 // Argument groups are nonatomic;
 // "<whitespace |between|the|bar|or|braces |is | OK>"
-ArgumentOptionalChoiceGroup = {
-    ( "[" ~ ArgumentAtom + ~ ( "|" ~ ArgumentAtom + ) * ~ "]" ) + }
-ArgumentRequiredChoiceGroup = {
-    ( "<" ~ ArgumentAtom + ~ ( "|" ~ ArgumentAtom + ) * ~ ">" ) + }
-ArgumentChoiceGroup = { ArgumentOptionalChoiceGroup
-                        | ArgumentRequiredChoiceGroup }
+
+ArgOptChoiceGroup = { ( "[" ~ Word + ~
+                      ( "|" ~ ( Word
+                              | ArgChoiceGroup ) + ) * ~
+                        "]" ) + }
+ArgReqChoiceGroup = { ( "<" ~ Word + ~
+                      ( "|" ~ ( Word
+                              | ArgChoiceGroup ) + ) * ~
+                        ">" ) + }
+ArgChoiceGroup    = _ { ArgOptChoiceGroup
+                      | ArgReqChoiceGroup }
 
 Command = {
-    ( WordOne | WordGroup ) ~
-    ( ArgumentChoiceOne | ArgumentChoiceGroup ) *
+    ( WordGroup ) ~
+    ( ArgChoiceGroup ) *
 }
 
 HelpMenu = {

--- a/derive/examples/help-menu.pest
+++ b/derive/examples/help-menu.pest
@@ -1,0 +1,36 @@
+WHITESPACE    = _{ " " }
+
+WordAtom  = ! { ( ASCII_ALPHANUMERIC | "_" | "-" ) + }
+WordOne   = { WordAtom }
+WordGroup = { WordAtom ~ ( " " ~ WordAtom ) * }
+
+ArgumentAtom = ! { ( ASCII_ALPHANUMERIC | "_" | "-" ) + }
+ArgumentRequiredChoiceOne = { "<" ~ ArgumentAtom ~ ">" }
+ArgumentOptionalChoiceOne = { "[" ~ ArgumentAtom ~ "]" }
+ArgumentChoiceOne = { ArgumentRequiredChoiceOne
+                      | ArgumentOptionalChoiceOne }
+
+// Argument groups are nonatomic;
+// "<whitespace |between|the|bar|or|braces |is | OK>"
+ArgumentOptionalChoiceGroup = {
+    ( "[" ~ ArgumentAtom + ~ ( "|" ~ ArgumentAtom + ) * ~ "]" ) + }
+ArgumentRequiredChoiceGroup = {
+    ( "<" ~ ArgumentAtom + ~ ( "|" ~ ArgumentAtom + ) * ~ ">" ) + }
+ArgumentChoiceGroup = { ArgumentOptionalChoiceGroup
+                        | ArgumentRequiredChoiceGroup }
+
+Command = {
+    ( WordOne | WordGroup ) ~
+    ( ArgumentChoiceOne | ArgumentChoiceGroup ) *
+}
+
+HelpMenu = {
+    SOI ~
+
+    (
+        Command ~
+        NEWLINE
+    ) * ~
+
+    EOI
+}

--- a/derive/examples/help-menu.rs
+++ b/derive/examples/help-menu.rs
@@ -12,6 +12,7 @@ const INPUT: &str = r"cli help
 cli positional-command <required-single-argument> [optional-single-argument]
 cli [choice | of | one | or | none | of | these | options]
 cli <choice | of | one | of | these | options>
+cli [nesting | <is | ok>]
 ";
 
 fn main() {

--- a/derive/examples/help-menu.rs
+++ b/derive/examples/help-menu.rs
@@ -10,23 +10,18 @@ struct HelpMenuGrammar;
 
 const INPUT: &str = r"cli help
 cli positional-command <required-single-argument> [optional-single-argument]
-cli [choice | of | these | options]
-cli <choice | of | these | required | options>
+cli [choice | of | one | or | none | of | these | options]
+cli <choice | of | one | of | these | options>
 ";
 
 fn main() {
-    match HelpMenuGrammar::parse(Rule::HelpMenu, &INPUT) {
-        Ok(mut file) => {
-            let file = file.next().expect("Infallible");
-            for line in file.into_inner() {
-                match line.as_rule() {
-                    Rule::Command => {
-                        println!("Line: {:#?}", line);
-                    }
-                    _ => (),
-                }
-            }
-        }
-        Err(e) => println!("Error parsing input: {}", e),
-    }
+    HelpMenuGrammar::parse(Rule::HelpMenu, INPUT)
+        .expect("Error parsing file")
+        .next()
+        .expect("Infallible")
+        .into_inner()
+        .filter(|pair| Rule::Command == pair.as_rule())
+        .for_each(|pair| {
+            println!("{:#?}", pair);
+        });
 }

--- a/derive/examples/help-menu.rs
+++ b/derive/examples/help-menu.rs
@@ -1,0 +1,32 @@
+#[macro_use]
+extern crate pest_derive;
+extern crate pest;
+
+use pest::Parser;
+
+#[derive(Parser)]
+#[grammar = "../examples/help-menu.pest"]
+struct HelpMenuGrammar;
+
+const INPUT: &str = r"cli help
+cli positional-command <required-single-argument> [optional-single-argument]
+cli [choice | of | these | options]
+cli <choice | of | these | required | options>
+";
+
+fn main() {
+    match HelpMenuGrammar::parse(Rule::HelpMenu, &INPUT) {
+        Ok(mut file) => {
+            let file = file.next().expect("Infallible");
+            for line in file.into_inner() {
+                match line.as_rule() {
+                    Rule::Command => {
+                        println!("Line: {:#?}", line);
+                    }
+                    _ => (),
+                }
+            }
+        }
+        Err(e) => println!("Error parsing input: {}", e),
+    }
+}


### PR DESCRIPTION
For `pest_derive`, an example program is added here which parses a common help menu format and dumps a part of the parse tree to stdout.