### PR TITLE
feat: add simple Position/Span From implementations for LineColLocation

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -74,6 +74,19 @@ pub enum LineColLocation {
     Span((usize, usize), (usize, usize)),
 }
 
+impl From<Position<'_>> for LineColLocation {
+    fn from(value: Position<'_>) -> Self {
+        Self::Pos(value.line_col())
+    }
+}
+
+impl From<Span<'_>> for LineColLocation {
+    fn from(value: Span<'_>) -> Self {
+        let (start, end) = value.split();
+        Self::Span(start.line_col(), end.line_col())
+    }
+}
+
 impl<R: RuleType> Error<R> {
     /// Creates `Error` from `ErrorVariant` and `Position`.
     ///

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -905,4 +905,26 @@ mod tests {
             .join("\n")
         );
     }
+
+    #[test]
+    fn pos_to_lcl_conversion() {
+        let input = "input";
+
+        let pos = Position::new(input, 2).unwrap();
+
+        assert_eq!(LineColLocation::Pos(pos.line_col()), pos.into());
+    }
+
+    #[test]
+    fn span_to_lcl_conversion() {
+        let input = "input";
+
+        let span = Span::new(input, 2, 4).unwrap();
+        let (start, end) = span.split();
+
+        assert_eq!(
+            LineColLocation::Span(start.line_col(), end.line_col()),
+            span.into()
+        );
+    }
 }


### PR DESCRIPTION
# What?
Adds `From<Position<'_>>` and `From<Span<'_>>` implementations to `LineColLocation`.

# Why?
This will make integrating Pest errors and types into custom error types slightly less verbose.
It's technically possible to create a pest error from a span and then get the LCL from that, but it's an unnecessary overhead.