### PR TITLE
Swap precedence of negation and factorial

### DIFF
--- a/derive/examples/calc.rs
+++ b/derive/examples/calc.rs
@@ -72,8 +72,8 @@ fn main() {
         .op(Op::infix(Rule::add, Left) | Op::infix(Rule::sub, Left))
         .op(Op::infix(Rule::mul, Left) | Op::infix(Rule::div, Left))
         .op(Op::infix(Rule::pow, Right))
-        .op(Op::postfix(Rule::fac))
-        .op(Op::prefix(Rule::neg));
+        .op(Op::prefix(Rule::neg))
+        .op(Op::postfix(Rule::fac));
 
     let stdin = stdin();
     let mut stdout = stdout();

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -142,8 +142,8 @@ impl<R: RuleType> BitOr for Op<R> {
 ///         .op(Op::infix(Rule::add, Assoc::Left) | Op::infix(Rule::sub, Assoc::Left))
 ///         .op(Op::infix(Rule::mul, Assoc::Left) | Op::infix(Rule::div, Assoc::Left))
 ///         .op(Op::infix(Rule::pow, Assoc::Right))
-///         .op(Op::postfix(Rule::fac))
-///         .op(Op::prefix(Rule::neg));
+///         .op(Op::prefix(Rule::neg))
+///         .op(Op::postfix(Rule::fac));
 /// ```
 ///
 /// To parse an expression, call the [`map_primary`], [`map_prefix`], [`map_postfix`],


### PR DESCRIPTION
Change `calc` example's behavior from
```
> -10!
-10! => ((-10)!) => 1
```
to
```
> -10!
-10! => (-(10!)) => -3628800
```

In my defense:
* [Google](https://www.google.ru/search?q=-10%21)
* [WolframAlpha](https://www.wolframalpha.com/input?i=-10%21)
* [The rust-analyzer guy](https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html):
> Well, let’s add `!` for factorials. It should bind tighter than `-`, because `-(92!)` is obviously more useful than `(-92)!`.
* The calculator in the start menu of my KDE Plasma:
![image](https://github.com/pest-parser/pest/assets/50824690/3b95716a-58e3-4def-9ef3-9599f12608af)


all share the same sentiment. That is, `-10! = -(10!)`