### PR TITLE
Make the root a value.

### DIFF
--- a/grammars/src/grammars/json.pest
+++ b/grammars/src/grammars/json.pest
@@ -10,7 +10,7 @@
 //! A parser for JSON file.
 //!
 //! And this is a example for JSON parser.
-json = { SOI ~ (object | array) ~ EOI }
+json = { SOI ~ value ~ EOI }
 
 /// Matches object, e.g.: `{ "foo": "bar" }`
 /// Foobar


### PR DESCRIPTION
JSON documents don't require being rooted at an object or an array