### PR TITLE
Merging Spans :recycle: 

### DIFF
--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -339,7 +339,7 @@ pub use crate::parser_state::{
     set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
 };
 pub use crate::position::Position;
-pub use crate::span::{Lines, LinesSpan, Span};
+pub use crate::span::{Lines, LinesSpan, Span, merge_spans};
 pub use crate::token::Token;
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -339,7 +339,7 @@ pub use crate::parser_state::{
     set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
 };
 pub use crate::position::Position;
-pub use crate::span::{Lines, LinesSpan, Span, merge_spans};
+pub use crate::span::{merge_spans, Lines, LinesSpan, Span};
 pub use crate::token::Token;
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -215,7 +215,7 @@ impl<'i> Span<'i> {
     /// Returns the input string of the `Span`.
     ///
     /// This function returns the input string of the `Span` as a `&str`. This is the source string
-    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of 
+    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of
     /// the `Span` or to perform further processing on the string.
     ///
     /// # Examples
@@ -223,7 +223,7 @@ impl<'i> Span<'i> {
     /// ```
     /// # use pest;
     /// # use pest::Span;
-    /// 
+    ///
     /// // Example: Get input string from a span
     /// let input = "abc\ndef\nghi";
     /// let span = Span::new(input, 1, 7).unwrap();
@@ -311,15 +311,15 @@ impl<'i> Hash for Span<'i> {
 
 /// Merges two spans into one.
 ///
-/// This function merges two spans that are contiguous or overlapping into a single span 
-/// that covers the entire range of the two input spans. This is useful when you want to 
+/// This function merges two spans that are contiguous or overlapping into a single span
+/// that covers the entire range of the two input spans. This is useful when you want to
 /// aggregate information from multiple spans into a single entity.
 ///
-/// The function checks if the input spans are overlapping or contiguous by comparing their 
-/// start and end positions. If they are, a new span is created with the minimum start position 
+/// The function checks if the input spans are overlapping or contiguous by comparing their
+/// start and end positions. If they are, a new span is created with the minimum start position
 /// and the maximum end position of the two input spans.
 ///
-/// If the input spans are neither overlapping nor contiguous, the function returns None, 
+/// If the input spans are neither overlapping nor contiguous, the function returns None,
 /// indicating that a merge operation was not possible.
 ///
 /// # Examples
@@ -335,14 +335,14 @@ impl<'i> Hash for Span<'i> {
 /// let span2 = Span::new(input, 7, 11).unwrap();
 /// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
-/// 
+///
 /// // Example 2: Overlapping spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 5, 11).unwrap();
 /// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
-/// 
+///
 /// // Example 3: Non-contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
@@ -353,7 +353,11 @@ impl<'i> Hash for Span<'i> {
 pub fn merge_spans<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
     if a.end() >= b.start() && a.start() <= b.end() {
         // The spans overlap or are contiguous, so they can be merged.
-        Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
+        Span::new(
+            a.get_input(),
+            core::cmp::min(a.start(), b.start()),
+            core::cmp::max(a.end(), b.end()),
+        )
     } else {
         // The spans don't overlap and aren't contiguous, so they can't be merged.
         None

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -212,6 +212,28 @@ impl<'i> Span<'i> {
         &self.input[self.start..self.end]
     }
 
+    /// Returns the input string of the `Span`.
+    ///
+    /// This function returns the input string of the `Span` as a `&str`. This is the source string
+    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of 
+    /// the `Span` or to perform further processing on the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pest;
+    /// # use pest::Span;
+    /// 
+    /// # Example: Get input string from a span
+    /// 
+    /// let input = "abc\ndef\nghi";
+    /// let span = Span::new(input, 1, 7).unwrap();
+    /// assert_eq!(span.get_input(), input);
+    /// ```
+    pub fn get_input(&self) -> &'i str {
+        self.input
+    }
+
     /// Iterates over all lines (partially) covered by this span. Yielding a `&str` for each line.
     ///
     /// # Examples
@@ -285,6 +307,57 @@ impl<'i> Hash for Span<'i> {
         (self.input as *const str).hash(state);
         self.start.hash(state);
         self.end.hash(state);
+    }
+}
+
+/// Merges two spans into one.
+///
+/// This function merges two spans that are contiguous or overlapping into a single span 
+/// that covers the entire range of the two input spans. This is useful when you want to 
+/// aggregate information from multiple spans into a single entity.
+///
+/// The function checks if the input spans are overlapping or contiguous by comparing their 
+/// start and end positions. If they are, a new span is created with the minimum start position 
+/// and the maximum end position of the two input spans.
+///
+/// If the input spans are neither overlapping nor contiguous, the function returns None, 
+/// indicating that a merge operation was not possible.
+///
+/// # Examples
+///
+/// ```
+/// # use pest;
+/// # use pest::Span;
+/// # use pest::Span::merge;
+///
+/// # Example 1: Contiguous spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 7, 11).unwrap();
+/// let merged = merge(&span1, &span2).unwrap();
+/// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+/// 
+/// # Example 2: Overlapping spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 5, 11).unwrap();
+/// let merged = merge(&span1, &span2).unwrap();
+/// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+/// 
+/// # Example 3: Non-contiguous spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 8, 11).unwrap();
+/// let merged = merge(&span1, &span2);
+/// assert!(merged.is_none());
+/// ```
+pub fn merge<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
+    if a.end() >= b.start() && a.start() <= b.end() {
+        // The spans overlap or are contiguous, so they can be merged.
+        Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
+    } else {
+        // The spans don't overlap and aren't contiguous, so they can't be merged.
+        None
     }
 }
 
@@ -446,5 +519,39 @@ mod tests {
                 .collect::<Vec<_>>(),
             lines
         );
+    }
+
+    #[test]
+    fn get_input() {
+        let input = "abc\ndef\nghi";
+        let span = Span::new(input, 1, 7).unwrap();
+        assert_eq!(span.get_input(), input);
+    }
+
+    #[test]
+    fn merge_contiguous() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 7, 11).unwrap();
+        let merged = merge(&span1, &span2).unwrap();
+        assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+    }
+
+    #[test]
+    fn merge_overlapping() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 5, 11).unwrap();
+        let merged = merge(&span1, &span2).unwrap();
+        assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+    }
+
+    #[test]
+    fn merge_non_contiguous() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 8, 11).unwrap();
+        let merged = merge(&span1, &span2);
+        assert!(merged.is_none());
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -224,8 +224,7 @@ impl<'i> Span<'i> {
     /// # use pest;
     /// # use pest::Span;
     /// 
-    /// # Example: Get input string from a span
-    /// 
+    /// // Example: Get input string from a span
     /// let input = "abc\ndef\nghi";
     /// let span = Span::new(input, 1, 7).unwrap();
     /// assert_eq!(span.get_input(), input);
@@ -328,30 +327,30 @@ impl<'i> Hash for Span<'i> {
 /// ```
 /// # use pest;
 /// # use pest::Span;
-/// # use pest::Span::merge;
+/// # use pest::merge_spans;
 ///
-/// # Example 1: Contiguous spans
+/// // Example 1: Contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 7, 11).unwrap();
-/// let merged = merge(&span1, &span2).unwrap();
+/// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
 /// 
-/// # Example 2: Overlapping spans
+/// // Example 2: Overlapping spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 5, 11).unwrap();
-/// let merged = merge(&span1, &span2).unwrap();
+/// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
 /// 
-/// # Example 3: Non-contiguous spans
+/// // Example 3: Non-contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 8, 11).unwrap();
-/// let merged = merge(&span1, &span2);
+/// let merged = merge_spans(&span1, &span2);
 /// assert!(merged.is_none());
 /// ```
-pub fn merge<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
+pub fn merge_spans<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
     if a.end() >= b.start() && a.start() <= b.end() {
         // The spans overlap or are contiguous, so they can be merged.
         Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
@@ -533,7 +532,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 7, 11).unwrap();
-        let merged = merge(&span1, &span2).unwrap();
+        let merged = merge_spans(&span1, &span2).unwrap();
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -542,7 +541,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 5, 11).unwrap();
-        let merged = merge(&span1, &span2).unwrap();
+        let merged = merge_spans(&span1, &span2).unwrap();
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -551,7 +550,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 8, 11).unwrap();
-        let merged = merge(&span1, &span2);
+        let merged = merge_spans(&span1, &span2);
         assert!(merged.is_none());
     }
 }


### PR DESCRIPTION
Hello Pest team!

I'm working on a Ctiny language interpreter for a university course. You can find my repository [here | GitHub](https://github.com/0nyr/ctiny_interpreter).

While working on the AST, I have faced a problem.

Considering the following grammar:

```
expression = { disjunction } // top level expression is disjunction
disjunction = { conjunction ~ (disjunction_operator ~ conjunction)* }
conjunction = { equality ~ (conjunction_operator ~ equality)* }
equality = { relation ~ (equality_operator ~ relation)* }
relation = { addition ~ (relation_operator ~ addition)? }
addition = { term ~ (addition_operator ~ term)* }
term = { factor ~ (multiplication_operator ~ factor)* }
factor = { unary_operator? ~ primary }
```

and my AST node structs:

```
// Base AST node
#[derive(Debug, PartialEq)]
pub struct Node<T> {
    pub sp: Span,   // contains information about the node's position (position of span) to be matched to string in the source code
    pub data: T,            // contains the data, wrapped into an inner type
}

// Expressions
#[derive(Debug, PartialEq)]
pub enum Expression {
    Literal(Literal), // direct value
    UnaryExpression(UnaryExpression),
    BinaryExpression(BinaryExpression),
    FunctionCall(FunctionCall),
    TypeCast(TypeCast),
    GetOrSetValue(GetOrSetValue),
}
```

While parsing the pairs of an expression, I want to be able to combine Spans to create Nodes of Expression::BinaryExpression for easier debugging later (giving the span of the Node to a pest::CustomError). But so far, there is no merge function for Span, and since there is no getter for the its `input` field... it would require me to pass everywhere the &str of the original input string... which is really annoying, especially considering I'm only manipulating pairs and spans that all have the reference I'm looking for. So the best approach to this is really to add a getter `get_input` and a `merge` function to Span.

You can have a look at this fork in action, specifically on span merging [here](https://github.com/0nyr/ctiny_interpreter/blob/2a0a4abbf4d2e4602a8a67b3e87b46c09c9f938b/src/abstract_syntax_tree/expressions.rs). Especially at the following code: 
```
let common_span = merge_spans_no_check!(
                &left_operation.sp,
                &right_operation.sp
            ).ok_or(make_ast_error_from_pair(
                $input_pair.clone(), 
                format!("🔴 Couldn't build a span from the left and right operations. 
                    str_len: {}, left_start: {}, left_end: {}, right_start: {}, right_end: {}",
                    $input_pair.as_str().len(),
                    left_operation.sp.start(),
                    left_operation.sp.end(),
                    right_operation.sp.start(),
                    right_operation.sp.end(),
                ).as_str())
            )?;
```

I'm not the only one facing this issue. A friend of mine, also working on this course is facing a similar issue.

That's what I have done with this PR. I also added meaningful documentation in comments as well as tests.