### PR TITLE
Adding get_input() to types that already have public as_str() 🏷️

### DIFF
--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -125,6 +125,38 @@ impl<'i, R: RuleType> Pair<'i, R> {
         &self.input[start..end]
     }
 
+    /// Returns the input string of the `Pair`.
+    ///
+    /// This function returns the input string of the `Pair` as a `&str`. This is the source string
+    /// from which the `Pair` was created. The returned `&str` can be used to examine the contents of
+    /// the `Pair` or to perform further processing on the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::rc::Rc;
+    /// # use pest;
+    /// # #[allow(non_camel_case_types)]
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// enum Rule {
+    ///     ab
+    /// }
+    ///
+    /// // Example: Get input string from a Pair
+    ///
+    /// let input = "ab";
+    /// let pair = pest::state(input, |state| {
+    ///     // generating Token pair with Rule::ab ...
+    /// #     state.rule(Rule::ab, |s| s.match_string("ab"))
+    /// }).unwrap().next().unwrap();
+    ///
+    /// assert_eq!(pair.as_str(), "ab");
+    /// assert_eq!(input, pair.get_input());
+    /// ```
+    pub fn get_input(&self) -> &'i str {
+        self.input
+    }
+
     /// Returns the `Span` defined by the `Pair`, consuming it.
     ///
     /// # Examples
@@ -425,5 +457,13 @@ mod tests {
         let pairs = pair.into_inner(); // the tokens b()
 
         assert_eq!(2, pairs.tokens().count());
+    }
+
+    #[test]
+    fn get_input_of_pair() {
+        let input = "abcde";
+        let pair = AbcParser::parse(Rule::a, input).unwrap().next().unwrap();
+        
+        assert_eq!(input, pair.get_input());
     }
 }

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -463,7 +463,7 @@ mod tests {
     fn get_input_of_pair() {
         let input = "abcde";
         let pair = AbcParser::parse(Rule::a, input).unwrap().next().unwrap();
-        
+
         assert_eq!(input, pair.get_input());
     }
 }

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -114,6 +114,40 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         }
     }
 
+    /// Returns the input string of `Pairs`.
+    ///
+    /// This function returns the input string of `Pairs` as a `&str`. This is the source string
+    /// from which `Pairs` was created. The returned `&str` can be used to examine the contents of
+    /// `Pairs` or to perform further processing on the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::rc::Rc;
+    /// # use pest;
+    /// # #[allow(non_camel_case_types)]
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// enum Rule {
+    ///     a,
+    ///     b
+    /// }
+    ///
+    /// // Example: Get input string from Pairs
+    ///
+    /// let input = "a b";
+    /// let pairs = pest::state(input, |state| {
+    ///     // generating Token pairs with Rule::a and Rule::b ...
+    /// #     state.rule(Rule::a, |s| s.match_string("a")).and_then(|s| s.skip(1))
+    /// #         .and_then(|s| s.rule(Rule::b, |s| s.match_string("b")))
+    /// }).unwrap();
+    ///
+    /// assert_eq!(pairs.as_str(), "a b");
+    /// assert_eq!(input, pairs.get_input());
+    /// ```
+    pub fn get_input(&self) -> &'i str {
+        self.input
+    }
+
     /// Captures inner token `Pair`s and concatenates resulting `&str`s. This does not capture
     /// the input between token `Pair`s.
     ///
@@ -525,6 +559,14 @@ mod tests {
         let pairs = AbcParser::parse(Rule::a, "abcde").unwrap();
 
         assert_eq!(pairs.as_str(), "abcde");
+    }
+
+    #[test]
+    fn get_input_of_pairs() {
+        let input = "abcde";
+        let pairs = AbcParser::parse(Rule::a, input).unwrap();
+
+        assert_eq!(pairs.get_input(), input);
     }
 
     #[test]

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -339,7 +339,7 @@ pub use crate::parser_state::{
     set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
 };
 pub use crate::position::Position;
-pub use crate::span::{Lines, LinesSpan, Span};
+pub use crate::span::{Lines, LinesSpan, Span, merge_spans};
 pub use crate::token::Token;
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -339,7 +339,7 @@ pub use crate::parser_state::{
     set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,
 };
 pub use crate::position::Position;
-pub use crate::span::{Lines, LinesSpan, Span, merge_spans};
+pub use crate::span::{merge_spans, Lines, LinesSpan, Span};
 pub use crate::token::Token;
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -215,7 +215,7 @@ impl<'i> Span<'i> {
     /// Returns the input string of the `Span`.
     ///
     /// This function returns the input string of the `Span` as a `&str`. This is the source string
-    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of 
+    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of
     /// the `Span` or to perform further processing on the string.
     ///
     /// # Examples
@@ -223,7 +223,7 @@ impl<'i> Span<'i> {
     /// ```
     /// # use pest;
     /// # use pest::Span;
-    /// 
+    ///
     /// // Example: Get input string from a span
     /// let input = "abc\ndef\nghi";
     /// let span = Span::new(input, 1, 7).unwrap();
@@ -311,15 +311,15 @@ impl<'i> Hash for Span<'i> {
 
 /// Merges two spans into one.
 ///
-/// This function merges two spans that are contiguous or overlapping into a single span 
-/// that covers the entire range of the two input spans. This is useful when you want to 
+/// This function merges two spans that are contiguous or overlapping into a single span
+/// that covers the entire range of the two input spans. This is useful when you want to
 /// aggregate information from multiple spans into a single entity.
 ///
-/// The function checks if the input spans are overlapping or contiguous by comparing their 
-/// start and end positions. If they are, a new span is created with the minimum start position 
+/// The function checks if the input spans are overlapping or contiguous by comparing their
+/// start and end positions. If they are, a new span is created with the minimum start position
 /// and the maximum end position of the two input spans.
 ///
-/// If the input spans are neither overlapping nor contiguous, the function returns None, 
+/// If the input spans are neither overlapping nor contiguous, the function returns None,
 /// indicating that a merge operation was not possible.
 ///
 /// # Examples
@@ -335,14 +335,14 @@ impl<'i> Hash for Span<'i> {
 /// let span2 = Span::new(input, 7, 11).unwrap();
 /// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
-/// 
+///
 /// // Example 2: Overlapping spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 5, 11).unwrap();
 /// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
-/// 
+///
 /// // Example 3: Non-contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
@@ -353,7 +353,11 @@ impl<'i> Hash for Span<'i> {
 pub fn merge_spans<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
     if a.end() >= b.start() && a.start() <= b.end() {
         // The spans overlap or are contiguous, so they can be merged.
-        Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
+        Span::new(
+            a.get_input(),
+            core::cmp::min(a.start(), b.start()),
+            core::cmp::max(a.end(), b.end()),
+        )
     } else {
         // The spans don't overlap and aren't contiguous, so they can't be merged.
         None

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -528,7 +528,7 @@ mod tests {
     fn get_input_of_span() {
         let input = "abc\ndef\nghi";
         let span = Span::new(input, 1, 7).unwrap();
-        
+
         assert_eq!(span.get_input(), input);
     }
 
@@ -538,7 +538,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 7, 11).unwrap();
         let merged = merge_spans(&span1, &span2).unwrap();
-        
+
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -548,7 +548,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 5, 11).unwrap();
         let merged = merge_spans(&span1, &span2).unwrap();
-        
+
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -558,7 +558,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 8, 11).unwrap();
         let merged = merge_spans(&span1, &span2);
-        
+
         assert!(merged.is_none());
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -212,6 +212,28 @@ impl<'i> Span<'i> {
         &self.input[self.start..self.end]
     }
 
+    /// Returns the input string of the `Span`.
+    ///
+    /// This function returns the input string of the `Span` as a `&str`. This is the source string
+    /// from which the `Span` was created. The returned `&str` can be used to examine the contents of 
+    /// the `Span` or to perform further processing on the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pest;
+    /// # use pest::Span;
+    /// 
+    /// # Example: Get input string from a span
+    /// 
+    /// let input = "abc\ndef\nghi";
+    /// let span = Span::new(input, 1, 7).unwrap();
+    /// assert_eq!(span.get_input(), input);
+    /// ```
+    pub fn get_input(&self) -> &'i str {
+        self.input
+    }
+
     /// Iterates over all lines (partially) covered by this span. Yielding a `&str` for each line.
     ///
     /// # Examples
@@ -285,6 +307,57 @@ impl<'i> Hash for Span<'i> {
         (self.input as *const str).hash(state);
         self.start.hash(state);
         self.end.hash(state);
+    }
+}
+
+/// Merges two spans into one.
+///
+/// This function merges two spans that are contiguous or overlapping into a single span 
+/// that covers the entire range of the two input spans. This is useful when you want to 
+/// aggregate information from multiple spans into a single entity.
+///
+/// The function checks if the input spans are overlapping or contiguous by comparing their 
+/// start and end positions. If they are, a new span is created with the minimum start position 
+/// and the maximum end position of the two input spans.
+///
+/// If the input spans are neither overlapping nor contiguous, the function returns None, 
+/// indicating that a merge operation was not possible.
+///
+/// # Examples
+///
+/// ```
+/// # use pest;
+/// # use pest::Span;
+/// # use pest::Span::merge;
+///
+/// # Example 1: Contiguous spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 7, 11).unwrap();
+/// let merged = merge(&span1, &span2).unwrap();
+/// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+/// 
+/// # Example 2: Overlapping spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 5, 11).unwrap();
+/// let merged = merge(&span1, &span2).unwrap();
+/// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+/// 
+/// # Example 3: Non-contiguous spans
+/// let input = "abc\ndef\nghi";
+/// let span1 = Span::new(input, 1, 7).unwrap();
+/// let span2 = Span::new(input, 8, 11).unwrap();
+/// let merged = merge(&span1, &span2);
+/// assert!(merged.is_none());
+/// ```
+pub fn merge<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
+    if a.end() >= b.start() && a.start() <= b.end() {
+        // The spans overlap or are contiguous, so they can be merged.
+        Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
+    } else {
+        // The spans don't overlap and aren't contiguous, so they can't be merged.
+        None
     }
 }
 
@@ -446,5 +519,39 @@ mod tests {
                 .collect::<Vec<_>>(),
             lines
         );
+    }
+
+    #[test]
+    fn get_input() {
+        let input = "abc\ndef\nghi";
+        let span = Span::new(input, 1, 7).unwrap();
+        assert_eq!(span.get_input(), input);
+    }
+
+    #[test]
+    fn merge_contiguous() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 7, 11).unwrap();
+        let merged = merge(&span1, &span2).unwrap();
+        assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+    }
+
+    #[test]
+    fn merge_overlapping() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 5, 11).unwrap();
+        let merged = merge(&span1, &span2).unwrap();
+        assert_eq!(merged, Span::new(input, 1, 11).unwrap());
+    }
+
+    #[test]
+    fn merge_non_contiguous() {
+        let input = "abc\ndef\nghi";
+        let span1 = Span::new(input, 1, 7).unwrap();
+        let span2 = Span::new(input, 8, 11).unwrap();
+        let merged = merge(&span1, &span2);
+        assert!(merged.is_none());
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -525,9 +525,10 @@ mod tests {
     }
 
     #[test]
-    fn get_input() {
+    fn get_input_of_span() {
         let input = "abc\ndef\nghi";
         let span = Span::new(input, 1, 7).unwrap();
+        
         assert_eq!(span.get_input(), input);
     }
 
@@ -537,6 +538,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 7, 11).unwrap();
         let merged = merge_spans(&span1, &span2).unwrap();
+        
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -546,6 +548,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 5, 11).unwrap();
         let merged = merge_spans(&span1, &span2).unwrap();
+        
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -555,6 +558,7 @@ mod tests {
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 8, 11).unwrap();
         let merged = merge_spans(&span1, &span2);
+        
         assert!(merged.is_none());
     }
 }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -224,8 +224,7 @@ impl<'i> Span<'i> {
     /// # use pest;
     /// # use pest::Span;
     /// 
-    /// # Example: Get input string from a span
-    /// 
+    /// // Example: Get input string from a span
     /// let input = "abc\ndef\nghi";
     /// let span = Span::new(input, 1, 7).unwrap();
     /// assert_eq!(span.get_input(), input);
@@ -328,30 +327,30 @@ impl<'i> Hash for Span<'i> {
 /// ```
 /// # use pest;
 /// # use pest::Span;
-/// # use pest::Span::merge;
+/// # use pest::merge_spans;
 ///
-/// # Example 1: Contiguous spans
+/// // Example 1: Contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 7, 11).unwrap();
-/// let merged = merge(&span1, &span2).unwrap();
+/// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
 /// 
-/// # Example 2: Overlapping spans
+/// // Example 2: Overlapping spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 5, 11).unwrap();
-/// let merged = merge(&span1, &span2).unwrap();
+/// let merged = merge_spans(&span1, &span2).unwrap();
 /// assert_eq!(merged, Span::new(input, 1, 11).unwrap());
 /// 
-/// # Example 3: Non-contiguous spans
+/// // Example 3: Non-contiguous spans
 /// let input = "abc\ndef\nghi";
 /// let span1 = Span::new(input, 1, 7).unwrap();
 /// let span2 = Span::new(input, 8, 11).unwrap();
-/// let merged = merge(&span1, &span2);
+/// let merged = merge_spans(&span1, &span2);
 /// assert!(merged.is_none());
 /// ```
-pub fn merge<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
+pub fn merge_spans<'i>(a: &Span<'i>, b: &Span<'i>) -> Option<Span<'i>> {
     if a.end() >= b.start() && a.start() <= b.end() {
         // The spans overlap or are contiguous, so they can be merged.
         Span::new(a.get_input(), std::cmp::min(a.start(), b.start()), std::cmp::max(a.end(), b.end()))
@@ -533,7 +532,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 7, 11).unwrap();
-        let merged = merge(&span1, &span2).unwrap();
+        let merged = merge_spans(&span1, &span2).unwrap();
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -542,7 +541,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 5, 11).unwrap();
-        let merged = merge(&span1, &span2).unwrap();
+        let merged = merge_spans(&span1, &span2).unwrap();
         assert_eq!(merged, Span::new(input, 1, 11).unwrap());
     }
 
@@ -551,7 +550,7 @@ mod tests {
         let input = "abc\ndef\nghi";
         let span1 = Span::new(input, 1, 7).unwrap();
         let span2 = Span::new(input, 8, 11).unwrap();
-        let merged = merge(&span1, &span2);
+        let merged = merge_spans(&span1, &span2);
         assert!(merged.is_none());
     }
 }


### PR DESCRIPTION
Hello Pest team.

This PR is a followup to my last PR [Merging Spans :recycle: #887](https://github.com/pest-parser/pest/pull/887#issue-1805224983).

In this last PR, I have introduced a getter for `Span` in order to be able to access the private `input` field of a `Span`. This allows to access the original input string without having to pass its reference everywhere in function arguments. In my personal project, I use this feature to be able to merge `Span`s.

There is no reason not to add this function to other types that also have this private field and a public `as_str()` function. I have added meaningful doc and tests and run `cargo fmt`.

I also renamed my tests to all have different names, making test debugging via commands like `cargo test <get_input_test> -- --nocapture` non-ambiguous. 