### PR TITLE
Add feature gated `Cow` module paths

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -540,8 +540,14 @@ fn generate_expr(expr: OptimizedExpr) -> TokenStream {
         #[cfg(feature = "grammar-extras")]
         OptimizedExpr::NodeTag(expr, tag) => {
             let expr = generate_expr(*expr);
+            let tag_cow = {
+                #[cfg(feature = "std")]
+                quote! { ::std::borrow::Cow::Borrowed(#tag) }
+                #[cfg(not(feature = "std"))]
+                quote! { ::alloc::borrow::Cow::Borrowed(#tag) }
+            };
             quote! {
-                #expr.and_then(|state| state.tag_node(alloc::borrow::Cow::Borrowed(#tag)))
+                #expr.and_then(|state| state.tag_node(#tag_cow))
             }
         }
     }
@@ -695,8 +701,14 @@ fn generate_expr_atomic(expr: OptimizedExpr) -> TokenStream {
         #[cfg(feature = "grammar-extras")]
         OptimizedExpr::NodeTag(expr, tag) => {
             let expr = generate_expr_atomic(*expr);
+            let tag_cow = {
+                #[cfg(feature = "std")]
+                quote! { ::std::borrow::Cow::Borrowed(#tag) }
+                #[cfg(not(feature = "std"))]
+                quote! { ::alloc::borrow::Cow::Borrowed(#tag) }
+            };
             quote! {
-                #expr.and_then(|state| state.tag_node(alloc::borrow::Cow::Borrowed(#tag)))
+                #expr.and_then(|state| state.tag_node(#tag_cow))
             }
         }
     }


### PR DESCRIPTION
The generator currently wraps tags in an instance of `alloc::borrow::Cow`. This PR changes that to `std::borrow::Cow` conditional on the `std` feature flag being active.

Closes #899.