### PR TITLE
docs: fix small typo in `match_range`

### DIFF
--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -701,7 +701,7 @@ impl<'i, R: RuleType> ParserState<'i, R> {
     /// `Box<ParserState>` if successful, or `Err` with the updated `Box<ParserState>` otherwise.
     ///
     /// # Caution
-    /// The provided `range` is intepreted as inclusive.
+    /// The provided `range` is interpreted as inclusive.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
`intepreted` -> `interpreted`

It may be a good idea to include [crates-ci/typos](https://github.com/crate-ci/typos), but it seems to throw a lot of false positives here.