### PR TITLE
small cargo clippy fixes + dependency bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           kind: check
-          toolchain: 1.64.0
+          toolchain: 1.70.0
       - name: cargo check
         run: cargo check --all --features pretty-print,const_prec_climber,memchr,grammar-extras --all-targets
 
@@ -40,7 +40,7 @@ jobs:
         with:
           kind: check
           components: clippy, rustfmt
-          toolchain: 1.64.0
+          toolchain: 1.70.0
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
@@ -62,7 +62,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.64.0
+          toolchain: 1.70.0
       - name: cargo doc
         run: cargo doc --all --features pretty-print,const_prec_climber,memchr,grammar-extras
 
@@ -123,7 +123,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.64.0
+          toolchain: 1.70.0
       - name: Check feature powerset
         run: cargo hack check --feature-powerset --optional-deps --exclude-all-features --skip not-bootstrap-in-src,cargo --keep-going --lib --tests --ignore-private
 
@@ -140,7 +140,7 @@ jobs:
         with:
           kind: check
           components: rust-src
-          toolchain: nightly-2023-03-20 # upgrade this regularly
+          toolchain: nightly-2023-08-20 # upgrade this regularly
       - name: check no_std compatibility
         run: cd pest && cargo build -j1 -Z build-std=core,alloc --no-default-features --target x86_64-unknown-linux-gnu
 
@@ -156,7 +156,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: nightly-2023-03-20
+          toolchain: nightly-2023-08-20
           tools: cargo-semver-checks
       - name: check semver compatibility
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           kind: check
           components: rust-src
-          toolchain: nightly-2023-08-20 # upgrade this regularly
+          toolchain: nightly-2023-03-20 # upgrade this regularly
       - name: check no_std compatibility
         run: cd pest && cargo build -j1 -Z build-std=core,alloc --no-default-features --target x86_64-unknown-linux-gnu
 
@@ -156,7 +156,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: nightly-2023-08-20
+          toolchain: nightly-2023-03-20
           tools: cargo-semver-checks
       - name: check semver compatibility
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.63.0 # needed for pest_debugger (linux-raw-sys v0.4.3 requires it)
+        uses: dtolnay/rust-toolchain@1.70.0 # needed for pest_debugger (clap_builder v4.4.1 requires it)
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "bootstrap",
     "debugger",

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>", "Tomas Tauber <me@tomtau.be>"]
 homepage = "https://pest.rs/"
@@ -14,9 +14,9 @@ readme = "_README.md"
 rust-version = "1.60"
 
 [dependencies]
-pest = { path = "../pest", version = "2.7.2" }
-pest_meta = { path = "../meta", version = "2.7.2" }
-pest_vm = { path = "../vm", version = "2.7.2" }
+pest = { path = "../pest", version = "2.7.3" }
+pest_meta = { path = "../meta", version = "2.7.3" }
+pest_vm = { path = "../vm", version = "2.7.3" }
 reqwest = { version = "= 0.11.13", default-features = false, features = ["blocking", "json", "default-tls"] }
 rustyline = "10"
 serde_json = "1"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -25,5 +25,5 @@ grammar-extras = ["pest_generator/grammar-extras"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.7.2", default-features = false }
-pest_generator = { path = "../generator", version = "2.7.2", default-features = false }
+pest = { path = "../pest", version = "2.7.3", default-features = false }
+pest_generator = { path = "../generator", version = "2.7.3", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -20,8 +20,8 @@ not-bootstrap-in-src = ["pest_meta/not-bootstrap-in-src"]
 grammar-extras = ["pest_meta/grammar-extras"]
 
 [dependencies]
-pest = { path = "../pest", version = "2.7.2", default-features = false }
-pest_meta = { path = "../meta", version = "2.7.2" }
+pest = { path = "../pest", version = "2.7.3", default-features = false }
+pest_meta = { path = "../meta", version = "2.7.3" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.60"
 
 [dependencies]
-pest = { path = "../pest", version = "2.7.2" }
-pest_derive = { path = "../derive", version = "2.7.2" }
+pest = { path = "../pest", version = "2.7.3" }
+pest_derive = { path = "../derive", version = "2.7.3" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -16,12 +16,12 @@ include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"
 rust-version = "1.60"
 
 [dependencies]
-pest = { path = "../pest", version = "2.7.2" }
+pest = { path = "../pest", version = "2.7.3" }
 once_cell = "1.8.0"
 
 [build-dependencies]
 sha2 = { version = "0.10", default-features = false }
-cargo = { version = "0.70", optional = true }
+cargo = { version = "0.72.2", optional = true }
 
 [features]
 default = []

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,7 +14,7 @@ readme = "_README.md"
 rust-version = "1.60"
 
 [features]
-default = ["std"]
+default = ["std", "memchr"]
 # Implements `std::error::Error` for the `Error` type
 std = ["ucd-trie/std", "dep:thiserror"]
 # Enables the `to_json` function for `Pair` and `Pairs`

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -570,13 +570,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = unexpected 4, 5, or 6; expected 1, 2, or 3",
+                "  = unexpected 4, 5, or 6; expected 1, 2, or 3"
             ]
             .join("\n")
         );
@@ -596,13 +596,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = expected 1 or 2",
+                "  = expected 1 or 2"
             ]
             .join("\n")
         );
@@ -622,13 +622,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = unexpected 4, 5, or 6",
+                "  = unexpected 4, 5, or 6"
             ]
             .join("\n")
         );
@@ -648,13 +648,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = unknown parsing error",
+                "  = unknown parsing error"
             ]
             .join("\n")
         );
@@ -673,13 +673,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = error: big one",
+                "  = error: big one"
             ]
             .join("\n")
         );
@@ -699,14 +699,14 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "3 | efgh",
                 "  |  ^^",
                 "  |",
-                "  = error: big one",
+                "  = error: big one"
             ]
             .join("\n")
         );
@@ -726,7 +726,7 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 1:2",
                 "  |",
                 "1 | ab",
@@ -734,7 +734,7 @@ mod tests {
                 "3 | efgh",
                 "  |  ^^",
                 "  |",
-                "  = error: big one",
+                "  = error: big one"
             ]
             .join("\n")
         );
@@ -754,14 +754,14 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 1:6",
                 "  |",
                 "1 | abcdef",
                 "2 | gh",
                 "  | ^----^",
                 "  |",
-                "  = error: big one",
+                "  = error: big one"
             ]
             .join("\n")
         );
@@ -784,13 +784,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 1:1",
                 "  |",
                 "1 | abcdef␊",
                 "  | ^-----^",
                 "  |",
-                "  = error: big one",
+                "  = error: big one"
             ]
             .join("\n")
         );
@@ -813,13 +813,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 1:1",
                 "  |",
                 "1 | ",
                 "  | ^",
                 "  |",
-                "  = error: empty",
+                "  = error: empty"
             ]
             .join("\n")
         );
@@ -840,13 +840,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> 2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = unexpected 5, 6, or 7; expected 2, 3, or 4",
+                "  = unexpected 5, 6, or 7; expected 2, 3, or 4"
             ]
             .join("\n")
         );
@@ -867,13 +867,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> file.rs:2:2",
                 "  |",
                 "2 | cd",
                 "  |  ^---",
                 "  |",
-                "  = unexpected 4, 5, or 6; expected 1, 2, or 3",
+                "  = unexpected 4, 5, or 6; expected 1, 2, or 3"
             ]
             .join("\n")
         );
@@ -894,13 +894,13 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            vec![
+            [
                 " --> file.rs:1:3",
                 "  |",
                 "1 | a	xbc",
                 "  |  	^---",
                 "  |",
-                "  = unexpected 4, 5, or 6; expected 1, 2, or 3",
+                "  = unexpected 4, 5, or 6; expected 1, 2, or 3"
             ]
             .join("\n")
         );

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -661,6 +661,8 @@ mod tests {
     }
 
     #[test]
+    // false positive: pest uses `..` as a complete range (historically)
+    #[allow(clippy::almost_complete_range)]
     fn test_tag_node_branch() {
         use crate::{state, ParseResult, ParserState};
         #[allow(non_camel_case_types)]

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -32,6 +32,8 @@ enum Rule {
 struct CalculatorParser;
 
 impl Parser<Rule> for CalculatorParser {
+    // false positive: pest uses `..` as a complete range (historically)
+    #[allow(clippy::almost_complete_range)]
     fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
         fn expression(
             state: Box<ParserState<'_, Rule>>,

--- a/pest/tests/json.rs
+++ b/pest/tests/json.rs
@@ -38,6 +38,8 @@ enum Rule {
 struct JsonParser;
 
 impl Parser<Rule> for JsonParser {
+    // false positive: pest uses `..` as a complete range (historically)
+    #[allow(clippy::almost_complete_range)]
     fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
         fn json(state: Box<ParserState<'_, Rule>>) -> ParseResult<Box<ParserState<'_, Rule>>> {
             value(state)

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.60"
 
 [dependencies]
-pest = { path = "../pest", version = "2.7.2" }
-pest_meta = { path = "../meta", version = "2.7.2" }
+pest = { path = "../pest", version = "2.7.3" }
+pest_meta = { path = "../meta", version = "2.7.3" }
 
 [features]
 grammar-extras = ["pest_meta/grammar-extras"]


### PR DESCRIPTION
memchr now supports aarch64, so it's made default: https://github.com/BurntSushi/memchr/pull/129
cargo lib (used in the not-bootstrap-in-src feature) did not respect umask: https://github.com/advisories/GHSA-j3xp-wfr4-hx87
(probably not an issue here)