### PR TITLE
Add allow(missing_docs) on Rule struct

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -220,7 +220,7 @@ fn generate_enum(
     let grammar_doc = &doc_comment.grammar_doc;
     let mut result = quote! {
         #[doc = #grammar_doc]
-        #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
+        #[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms, missing_docs)]
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     };
     if non_exhaustive {


### PR DESCRIPTION
This PR adds `#[allow(missing_docs)]` to the `Rule` struct in order to fix https://github.com/pest-parser/pest/issues/326.

The only element which was missing documentation for me was the `EOI` variant, tell me if you would rather add some hardcoded documentation to that variant.
