### PR TITLE
bump MSRV to 1.61 (due to memchr's MSRV)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
   toolchain:
     description: Toolchain version
     required: false
-    default: "1.60.0"
+    default: "1.61.0"
   components:
     description: Toolchain components
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           kind: msrv
           tools: cargo-msrv
-          toolchain: 1.60.0
+          toolchain: 1.61.0
       - name: Check msrv
         shell: sh
         run: for crate in "derive" "generator" "grammars" "meta" "pest" "vm"; do cd "$crate" && cargo msrv verify && cd ..; done

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![pest Continuous Integration](https://github.com/pest-parser/pest/actions/workflows/ci.yml/badge.svg)](https://github.com/pest-parser/pest/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pest-parser/pest/branch/master/graph/badge.svg)](https://codecov.io/gh/pest-parser/pest)
-<a href="https://blog.rust-lang.org/2021/11/01/Rust-1.60.0.html"><img alt="Rustc Version 1.60.0+" src="https://img.shields.io/badge/rustc-1.60.0%2B-lightgrey.svg"/></a>
+<a href="https://blog.rust-lang.org/2021/11/01/Rust-1.61.0.html"><img alt="Rustc Version 1.61.0+" src="https://img.shields.io/badge/rustc-1.61.0%2B-lightgrey.svg"/></a>
 
 [![Crates.io](https://img.shields.io/crates/d/pest.svg)](https://crates.io/crates/pest)
 [![Crates.io](https://img.shields.io/crates/v/pest.svg)](https://crates.io/crates/pest)
@@ -204,8 +204,7 @@ You can find more projects and ecosystem tools in the [awesome-pest](https://git
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with default features on **Rust 1.60.0**
-or **Rust 1.61** with `const_prec_climber`.
+This library should always compile with default features on **Rust 1.61.0**.
 
 ## no_std support
 

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/pest-parser/pest"
 documentation = "https://docs.rs/pest"
 publish = false
 license = "MIT OR Apache-2.0"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 pest_generator = "2.1.1" # Use the crates-io version, which (should be) known-good

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "grammar", "debugger"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 pest = { path = "../pest", version = "2.7.3" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "parser", "peg", "grammar"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [lib]
 name = "pest_derive"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "generator"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [features]
 default = ["std"]

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "parser", "peg", "grammar"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 pest = { path = "../pest", version = "2.7.3" }

--- a/grammars/fuzz/Cargo.toml
+++ b/grammars/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "pest_grammars-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-rust-version = "1.60"
+rust-version = "1.61"
 
 [package.metadata]
 cargo-fuzz = true

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 readme = "_README.md"
 exclude = ["src/grammar.pest"]
 include = ["Cargo.toml", "src/**/*", "src/grammar.rs", "_README.md", "LICENSE-*"]
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 pest = { path = "../pest", version = "2.7.3" }

--- a/meta/fuzz/Cargo.toml
+++ b/meta/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "pest_meta-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-rust-version = "1.60"
+rust-version = "1.61"
 
 [package.metadata]
 cargo-fuzz = true

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "parser", "peg", "grammar"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [features]
 default = ["std", "memchr"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "vm"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [dependencies]
 pest = { path = "../pest", version = "2.7.3" }


### PR DESCRIPTION
memchr is now enabled by default and its latest version's MSRV is 1.61