### PR TITLE
Update pest_derive to generate a list of all rules in Rule::all_rules().

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -811,9 +811,9 @@ mod tests {
                     #[doc = "This is rule comment"]
                     r#f
                 }
-                impl Rule { 
+                impl Rule {
                     pub fn all_rules() -> &'static [Rule] {
-                        &[Rule::r#f] 
+                        &[Rule::r#f]
                     }
                 }
             }


### PR DESCRIPTION
This function returns all variants of the generated Rule so that they can be enumerated/searched for/etc. Also updated the tests to reflect the new output. 

The motivation for this is that I'd like to write a program to automatically verify some properties of the grammar that I'm working on, but the Rule type that is used by the generated parser is an enum. The Rust language doesn't provide any way to enumerate an enum unless you make a matching variable to hold all the variants and keep it in sync fastidiously (this kind of thing makes me tired and anxious). There are crates like strum that automate this, of course, but pest doesn't currently depend on any of those. 

This change just makes the generator also produce a function that returns a variable with all of the Rule variants. That is just enough that you can iterate through all of the rules in the grammar, and with the generated Debug trait on Rule, you could also make yourself a way to look up a Rule variant by its name if you need that (I do).

I've already gotten my main program working with this change, so I'm hoping you guys are open to something like this. Happy to iterate. 