### PR TITLE
Export generator and docs api in the pest_generator trait

### DIFF
--- a/generator/src/docs.rs
+++ b/generator/src/docs.rs
@@ -1,9 +1,13 @@
+//! Type and helper to collect the gramamr and rule documentation.
+
 use pest::iterators::Pairs;
 use pest_meta::parser::Rule;
 use std::collections::HashMap;
 
+/// Abstraction for the grammer and rule doc.
 #[derive(Debug)]
-pub(crate) struct DocComment {
+pub struct DocComment {
+    /// The grammar documentation is defined at the beginning of a file with //!.
     pub grammar_doc: String,
 
     /// HashMap for store all doc_comments for rules.
@@ -33,7 +37,7 @@ pub(crate) struct DocComment {
 /// grammar_doc = "This is a grammar doc"
 /// line_docs = { "foo": "line doc 1\nline doc 2", "bar": "line doc 3" }
 /// ```
-pub(crate) fn consume(pairs: Pairs<'_, Rule>) -> DocComment {
+pub fn consume(pairs: Pairs<'_, Rule>) -> DocComment {
     let mut grammar_doc = String::new();
 
     let mut line_docs: HashMap<String, String> = HashMap::new();

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+//! Helpers to generate the code for the Parser `derive``.
+
 use std::path::PathBuf;
 
 use proc_macro2::TokenStream;
@@ -20,7 +22,10 @@ use pest_meta::optimizer::*;
 use crate::docs::DocComment;
 use crate::ParsedDerive;
 
-pub(crate) fn generate(
+/// Generates the corresponding parser based based on the processed macro input. If `include_grammar`
+/// is set to true, it'll generate an explicit "include_str" statement (done in pest_derive, but
+/// turned off in the local bootstrap).
+pub fn generate(
     parsed_derive: ParsedDerive,
     paths: Vec<PathBuf>,
     rules: Vec<OptimizedRule>,

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -26,13 +26,14 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
 
+use generator::generate;
 use proc_macro2::TokenStream;
 use syn::{Attribute, DeriveInput, Expr, ExprLit, Generics, Ident, Lit, Meta};
 
 #[macro_use]
 mod macros;
-mod docs;
-mod generator;
+pub mod docs;
+pub mod generator;
 
 use pest_meta::parser::{self, rename_meta_rule, Rule};
 use pest_meta::{optimizer, unwrap_or_report, validator};
@@ -96,7 +97,7 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
     let ast = unwrap_or_report(parser::consume_rules(pairs));
     let optimized = optimizer::optimize(ast);
 
-    generator::generate(
+    generate(
         parsed_derive,
         paths,
         optimized,
@@ -119,10 +120,14 @@ enum GrammarSource {
     Inline(String),
 }
 
-struct ParsedDerive {
-    pub(crate) name: Ident,
-    pub(crate) generics: Generics,
-    pub(crate) non_exhaustive: bool,
+/// Parsed information of the derive and the attributes.
+pub struct ParsedDerive {
+    /// The identifier of the deriving struct, union, or enum.
+    pub name: Ident,
+    /// The generics of the deriving struct, union, or enum.
+    pub generics: Generics,
+    /// Indicates whether the 'non_exhaustive' attribute is added to the 'Rule' enum.
+    pub non_exhaustive: bool,
 }
 
 fn parse_derive(ast: DeriveInput) -> (ParsedDerive, Vec<GrammarSource>) {


### PR DESCRIPTION
### What it does
This PR exposes the docs module and the generator module of the pest_generator trait.
I added the missing docs for the newly exported functions, structs and modules.

### Background
We are currently working on a language workbench in rust based on pest. So far we have used a separate derive macro by. But it turns out that it is easier if we do our own preprocessing of the derive attributes and just generate the parser in our own derive macro with the `pest_generaotr::generator::generate` function.
 
### Improvements
We can add a feature flag as this API was not intended to be semver sensitive.