### PR TITLE
Add docs to parsing source code

### DIFF
--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -15,6 +15,10 @@ fn main() {
         env!("CARGO_MANIFEST_DIR"),
         "/../meta/src/grammar.pest"
     ));
+    // Path on which we should write generated grammar file.
+    // In case `not-bootstrap-in-src` is:
+    // * OFF -> in `grammar.rs` next to `grammar.pest`
+    // * ON  -> in `target/build/.../__pest_grammar.rs` directory as specified in `meta/build.rs`
     let rs: PathBuf = if should_bootstrap_in_src() {
         Path::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -33,6 +37,8 @@ fn main() {
             #[grammar = #path]
             pub struct PestParser;
         };
+        // Passing value to `derive_parser` as if there was a derive annotation
+        // next to the struct above.
         derive_parser(pest, false)
     };
 

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -59,6 +59,7 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
     let ast: DeriveInput = syn::parse2(input).unwrap();
     let (parsed_derive, contents) = parse_derive(ast);
 
+    // Grammar presented in a view of a string.
     let mut data = String::new();
     let mut paths = vec![];
 
@@ -101,6 +102,7 @@ pub fn derive_parser(input: TokenStream, include_grammar: bool) -> TokenStream {
         }
     }
 
+    // `Rule::grammar_rules` is taken from meta/srd/parser.rs.
     let pairs = match parser::parse(Rule::grammar_rules, &data) {
         Ok(pairs) => pairs,
         Err(error) => panic!("error parsing \n{}", error.renamed_rules(rename_meta_rule)),

--- a/meta/build.rs
+++ b/meta/build.rs
@@ -49,7 +49,11 @@ fn main() {
         sha.update(current_grammar.as_bytes());
         let current_hash = display_digest(&sha.finalize());
 
-        // If `grammar.pest` has changed
+        // If `grammar.pest` has changed.
+        // Other-words one of these variants:
+        // * grammar.rs doesn't exits
+        // * grammar.rs exists, but `old_hash` doesn't exists (seems like internal error)
+        // * grammar.rs exists, but `old_hash` doesn't equal to current_hash (it means grammar.pest)
         if !grammar_rs_path.exists()
             || old_hash.as_ref().map(|it| it.trim()) != Some(current_hash.trim())
         {
@@ -60,6 +64,7 @@ fn main() {
 
             #[cfg(not(feature = "not-bootstrap-in-src"))]
             {
+                // We want to store `grammar.rs` next to `grammar.pest`.
                 // This "dynamic linking" is probably so fragile I don't even want to hear it
                 let status = Command::new(manifest_dir.join("../target/debug/pest_bootstrap"))
                     .spawn()
@@ -109,7 +114,7 @@ fn main() {
                 }
             }
         } else {
-            println!("       Fresh `meta/src/grammar.rs`");
+            println!("       Previous `meta/src/grammar.rs`");
         }
     } else {
         assert!(

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -20,6 +20,10 @@ use pest::{Parser, Position, Span};
 use crate::ast::{Expr, Rule as AstRule, RuleType};
 use crate::validator;
 
+/// Note: `include!` adds here a code generated from build.rs file.
+/// In case feature `not-bootstrap-in-src` is:
+/// * OFF  -> include generated `grammar.rs` file from meta/src
+/// * ON   -> include generated `__pest_grammar.rs` file from target/build/...
 #[allow(missing_docs, unused_qualifications)]
 mod grammar {
     #[cfg(not(feature = "not-bootstrap-in-src"))]
@@ -29,6 +33,7 @@ mod grammar {
     include!(concat!(env!("OUT_DIR"), "/__pest_grammar.rs"));
 }
 
+/// Import included grammar (`PestParser` class globally for current module).
 pub use self::grammar::*;
 
 /// A helper that will parse using the pest grammar

--- a/pest/src/iterators/queueable_token.rs
+++ b/pest/src/iterators/queueable_token.rs
@@ -16,13 +16,19 @@
 #[derive(Debug)]
 pub enum QueueableToken<'i, R> {
     Start {
+        /// Queue (as a vec) contains both `Start` token and `End` for the same rule.
+        /// This field is an index of corresponding `End` token in vec.
         end_token_index: usize,
+        /// Position from which rule was tried to parse (or successfully parsed).
         input_pos: usize,
     },
     End {
+        /// Queue (as a vec) contains both `Start` token and `End` for the same rule.
+        /// This filed is an index of corresponding `Start` token in vec.
         start_token_index: usize,
         rule: R,
         tag: Option<&'i str>,
+        /// Position at which successfully parsed rule finished (ended).
         input_pos: usize,
     },
 }


### PR DESCRIPTION
While exploring source code (mostly `parser_state.rs`) I've left some comments for better understanding of parsing process.
I thought maybe they'll be useful for other contributors.