### PR TITLE
perf: skipper support inlining

### DIFF
--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -30,10 +30,11 @@ mod unroller;
 
 /// Takes pest's ASTs and optimizes them
 pub fn optimize(rules: Vec<Rule>) -> Vec<OptimizedRule> {
+    let map = to_hash_map(&rules);
     let optimized: Vec<OptimizedRule> = rules
         .into_iter()
         .map(rotater::rotate)
-        .map(skipper::skip)
+        .map(|rule| skipper::skip(rule, &map))
         .map(unroller::unroll)
         .map(concatenator::concatenate)
         .map(factorizer::factor)
@@ -41,10 +42,10 @@ pub fn optimize(rules: Vec<Rule>) -> Vec<OptimizedRule> {
         .map(rule_to_optimized_rule)
         .collect();
 
-    let rules = to_hash_map(&optimized);
+    let optimized_map = to_optimized_hash_map(&optimized);
     optimized
         .into_iter()
-        .map(|rule| restorer::restore_on_err(rule, &rules))
+        .map(|rule| restorer::restore_on_err(rule, &optimized_map))
         .collect()
 }
 
@@ -87,12 +88,18 @@ fn rule_to_optimized_rule(rule: Rule) -> OptimizedRule {
     }
 }
 
-fn to_hash_map(rules: &[OptimizedRule]) -> HashMap<String, OptimizedExpr> {
-    rules
-        .iter()
-        .map(|r| (r.name.clone(), r.expr.clone()))
-        .collect()
+macro_rules! to_hash_map {
+    ($func_name:ident, $rule:ty, $expr:ty) => {
+        fn $func_name(rules: &[$rule]) -> HashMap<String, $expr> {
+            rules
+                .iter()
+                .map(|r| (r.name.clone(), r.expr.clone()))
+                .collect()
+        }
+    };
 }
+to_hash_map!(to_hash_map, Rule, Expr);
+to_hash_map!(to_optimized_hash_map, OptimizedRule, OptimizedExpr);
 
 /// The optimized version of the pest AST's `Rule`.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/meta/src/optimizer/restorer.rs
+++ b/meta/src/optimizer/restorer.rs
@@ -103,7 +103,7 @@ mod tests {
         }];
 
         assert_eq!(
-            restore_on_err(rules[0].clone(), &to_hash_map(&rules)),
+            restore_on_err(rules[0].clone(), &to_optimized_hash_map(&rules)),
             rules[0].clone()
         );
     }
@@ -123,7 +123,7 @@ mod tests {
         };
 
         assert_eq!(
-            restore_on_err(rules[0].clone(), &to_hash_map(&rules)),
+            restore_on_err(rules[0].clone(), &to_optimized_hash_map(&rules)),
             restored
         );
     }
@@ -146,7 +146,7 @@ mod tests {
         };
 
         assert_eq!(
-            restore_on_err(rules[0].clone(), &to_hash_map(&rules)),
+            restore_on_err(rules[0].clone(), &to_optimized_hash_map(&rules)),
             restored
         );
     }

--- a/meta/src/optimizer/skipper.rs
+++ b/meta/src/optimizer/skipper.rs
@@ -22,6 +22,16 @@ pub fn skip(rule: Rule, map: &HashMap<String, Expr>) -> Rule {
                 if let Expr::Str(string) = *lhs {
                     choices.push(string);
                     populate_choices(*rhs, map, choices)
+                } else if let Expr::Ident(name) = *lhs {
+                    if let Some(Expr::Skip(mut inlined_choices)) = map
+                        .get(&name)
+                        .and_then(|expr| populate_choices(expr.clone(), map, vec![]))
+                    {
+                        choices.append(&mut inlined_choices);
+                        populate_choices(*rhs, map, choices)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/meta/src/optimizer/skipper.rs
+++ b/meta/src/optimizer/skipper.rs
@@ -23,6 +23,7 @@ pub fn skip(rule: Rule, map: &HashMap<String, Expr>) -> Rule {
                     choices.push(string);
                     populate_choices(*rhs, map, choices)
                 } else if let Expr::Ident(name) = *lhs {
+                    // Try inlining rule in choices
                     if let Some(Expr::Skip(mut inlined_choices)) = map
                         .get(&name)
                         .and_then(|expr| populate_choices(expr.clone(), map, vec![]))
@@ -40,6 +41,7 @@ pub fn skip(rule: Rule, map: &HashMap<String, Expr>) -> Rule {
                 choices.push(string);
                 Some(Expr::Skip(choices))
             }
+            // Try inlining single rule
             Expr::Ident(name) => map
                 .get(&name)
                 .and_then(|expr| populate_choices(expr.clone(), map, choices)),


### PR DESCRIPTION
The code that was previously not optimized into Expr::Skip looked like this:
```
inline = {"a"}
skip = { (!(inline | "b") ~ ANY)* }
```
It had to be written like this to achieve the desired optimization, which means we have to inline rule manually:
```
skip = { (!("a" | "b") ~ ANY)* }
```
This PR automates this optimization, enabling the automatic inlining of simple rules.