### PR TITLE
Avoid computing line offsets after the last token

### DIFF
--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -32,13 +32,14 @@ pub struct FlatPairs<'i, R> {
 pub fn new<'i, R: RuleType>(
     queue: Rc<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
+    line_index: Rc<LineIndex>,
     start: usize,
     end: usize,
 ) -> FlatPairs<'i, R> {
     FlatPairs {
         queue,
         input,
-        line_index: Rc::new(LineIndex::new(input)),
+        line_index,
         start,
         end,
     }

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -51,7 +51,17 @@ pub fn new<'i, R: RuleType>(
 ) -> Pairs<'i, R> {
     let line_index = match line_index {
         Some(line_index) => line_index,
-        None => Rc::new(LineIndex::new(input)),
+        None => {
+            let last_input_pos = queue
+                .last()
+                .map(|token| match *token {
+                    QueueableToken::Start { input_pos, .. }
+                    | QueueableToken::End { input_pos, .. } => input_pos,
+                })
+                .unwrap_or(0);
+
+            Rc::new(LineIndex::new(&input[..last_input_pos]))
+        }
     };
 
     let mut pairs_count = 0;
@@ -205,7 +215,13 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     /// ```
     #[inline]
     pub fn flatten(self) -> FlatPairs<'i, R> {
-        flat_pairs::new(self.queue, self.input, self.start, self.end)
+        flat_pairs::new(
+            self.queue,
+            self.input,
+            self.line_index,
+            self.start,
+            self.end,
+        )
     }
 
     /// Finds the first pair that has its node or branch tagged with the provided


### PR DESCRIPTION
This pull request changes the logic which precomputes line endings so that it stops after the end index of the last token in the parse output.

Background: I've integrated pest into a tool which parses partially structured data. When I identify certain kinds of data, I call pest to parse a single item at the start of the input. (It isn't easily possible to determine how long an item might be without parsing it, so I can't pass pest only the source it needs for the current item.) This mostly works great, but I noticed that on some inputs it was unexpectedly slow, and that the vast majority of the time was being spent in `pest::iterators::line_index::LineIndex::new()`. This was because each time pest completed a toplevel parse it would then precompute line endings for the rest of the input string, even though only at most a few kilobytes at the start of the string were parsed.

This change takes the time to process a 23MB, 300,000-line document with 32,000 separate pest parse calls down from two minutes to about 4 seconds.