### PR TITLE
nit: fix minor typo in usage of it's vs its in the docs

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -180,7 +180,7 @@
 //! | `e?`                  | optionally matches `e`                                     |
 //! | `&e`                  | matches `e` without making progress                        |
 //! | `!e`                  | matches if `e` doesn't match without making progress       |
-//! | `PUSH(e)`             | matches `e` and pushes it's captured string down the stack |
+//! | `PUSH(e)`             | matches `e` and pushes its captured string down the stack  |
 //!
 //! where `e`, `e1`, and `e2` are expressions.
 //!
@@ -191,7 +191,7 @@
 //! // input: ab_bb_b
 //!
 //! identifier = @{ "a" ~ ("b"|"_")* ~ "b" }
-//! // matches:      a     b_bb_b       nothing -> error!      
+//! // matches:      a     b_bb_b       nothing -> error!
 //!
 //! identifier = @{ "a" ~ ("_"* ~ "b")* }
 //! // matches:      a     b, _bb, _b   in three repetitions

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -407,7 +407,7 @@ pub struct ParserState<'i, R: RuleType> {
     position: Position<'i>,
     /// Queue representing rules partially (`QueueableToken::Start`) and
     /// totally (`QueueableToken::End`) parsed. When entering rule we put it in the queue in a state
-    /// of `Start` and after all it's sublogic (subrules or strings) are parsed, we change it to
+    /// of `Start` and after all its sublogic (subrules or strings) are parsed, we change it to
     /// `End` state.
     queue: Vec<QueueableToken<'i, R>>,
     /// Status set in case specific lookahead logic is used in grammar.
@@ -1359,7 +1359,7 @@ impl<'i, R: RuleType> ParserState<'i, R> {
         F: FnOnce(Box<Self>) -> ParseResult<Box<Self>>,
     {
         self = self.inc_call_check_limit()?;
-        // In case child parsing call is another `atomic` it will have it's own atomicity status.
+        // In case child parsing call is another `atomic` it will have its own atomicity status.
         let initial_atomicity = self.atomicity;
         // In case child atomicity is the same as we've demanded, we shouldn't do nothing.
         // E.g. we have the following rules:


### PR DESCRIPTION
Noticed this while browsing the docs, might as well help fix.