### PR TITLE
Band-Aid: fix one of the left recursion bugs (fixes #1047)

### DIFF
--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -667,7 +667,7 @@ fn left_recursion<'a, 'i: 'a>(rules: HashMap<String, &'a ParserNode<'i>>) -> Vec
                 None
             }
             ParserExpr::Seq(ref lhs, ref rhs) => {
-                if is_non_failing(&lhs.expr, rules, &mut vec![trace.last().unwrap().clone()]) {
+                if is_non_failing(&lhs.expr, rules, &mut vec![trace.last().unwrap().clone()]) || is_non_progressing(&lhs.expr, rules, &mut vec![trace.last().unwrap().clone()]){
                     check_expr(rhs, rules, trace)
                 } else {
                     check_expr(lhs, rules, trace)


### PR DESCRIPTION
This is a band-aid. Comments in the code indicate that left recursion validation has probably other edge cases/bugs.

This fixes #1047 and successfully detects the left-recursion. Here is the output message when running `cargo build`:
```
error: proc-macro derive panicked
 --> src\main.rs:4:10
  |
4 | #[derive(Parser)]
  |          ^^^^^^
  |
  = help: message: grammar error

           --> 1:19
            |
          1 | expr = { !(EOI) ~ expr ~ "infix" ~ expr }
            |                   ^--^
            |
            = rule expr is left-recursive (expr -> expr); pest::pratt_parser might be useful in this case
```