### PR TITLE
bump release toolchain for pest_debugger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.70.0 # needed for pest_debugger (clap_builder v4.4.1 requires it)
+        uses: dtolnay/rust-toolchain@1.74.0 # needed for pest_debugger (clap requires it)
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Rust toolchain version 1.74.0
	- Upgraded toolchain for release process compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->