### PR TITLE
Debugger: Fix deadlock on Windows

### DIFF
--- a/debugger/src/lib.rs
+++ b/debugger/src/lib.rs
@@ -252,9 +252,13 @@ impl DebuggerContext {
                     if is_done_signal.load(Ordering::SeqCst) {
                         return true;
                     }
-                    let lock = breakpoints.lock().expect(POISONED_LOCK_PANIC);
 
-                    if lock.contains(&rule) {
+                    let contains_rule = {
+                        let lock = breakpoints.lock().expect(POISONED_LOCK_PANIC);
+                        lock.contains(&rule)
+                    };
+
+                    if contains_rule {
                         rsender
                             .send(DebuggerEvent::Breakpoint(rule, pos.pos()))
                             .expect(CHANNEL_CLOSED_PANIC);


### PR DESCRIPTION
The debugger locks the breakpoint list before calling the breakpoint handler, and only releases the lock after the call has been issued. On Windows, this makes it impossible to add/delete breakpoints when the debugger broke at a breakpoint (see #1071). This PR fixes the issue by releasing the breakpoint list lock before calling the breakpoint handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code readability in debugger context handling
	- Restructured internal logic for breakpoint checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->