### PR TITLE
check if a crate version was already published

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -50,6 +50,11 @@ wait_until_available() {
 
 for crate in ${CRATES}; do
   VERSION="$(get_local_version "${crate}")"
-  publish "${crate}"
-  wait_until_available "${crate}" "${VERSION}"
+  ONLINE_DATE="$(check_version_online "${crate}" "${VERSION}")"
+  if [ -n "${ONLINE_DATE}" ]; then
+    echo "Crate ${crate} is already published"
+  else
+    publish "${crate}"
+    wait_until_available "${crate}" "${VERSION}"
+  fi
 done


### PR DESCRIPTION
(to allow re-running the script if some crate versions weren't published for some reason)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the publishing process by adding a check for items already available online.
  - Now displays an informative message when an item is already published, avoiding redundant actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->