### PR TITLE
new rule: PUSH_LITERAL

### DIFF
--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -570,6 +570,11 @@ fn generate_expr(expr: OptimizedExpr) -> TokenStream {
                 state.stack_push(|state| #expr)
             }
         }
+        OptimizedExpr::PushLiteral(string) => {
+            quote! {
+                state.stack_push_literal(#string)
+            }
+        }
         OptimizedExpr::RestoreOnErr(expr) => {
             let expr = generate_expr(*expr);
 
@@ -753,6 +758,11 @@ fn generate_expr_atomic(expr: OptimizedExpr) -> TokenStream {
 
             quote! {
                 state.stack_push(|state| #expr)
+            }
+        }
+        OptimizedExpr::PushLiteral(string) => {
+            quote! {
+                state.stack_push_literal(#string)
             }
         }
         OptimizedExpr::RestoreOnErr(expr) => {

--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -94,6 +94,8 @@ pub enum Expr {
     Skip(Vec<String>),
     /// Matches an expression and pushes it to the stack, e.g. `push(e)`
     Push(Box<Expr>),
+    /// Pushes a literal string to the stack, e.g. `push_literal("a")`
+    PushLiteral(String),
     /// Matches an expression and assigns a label to it, e.g. #label = exp
     #[cfg(feature = "grammar-extras")]
     NodeTag(Box<Expr>, String),
@@ -319,6 +321,7 @@ impl core::fmt::Display for Expr {
                 write!(f, "(!({}) ~ ANY)*", strings)
             }
             Expr::Push(expr) => write!(f, "PUSH({})", expr),
+            Expr::PushLiteral(s) => write!(f, "PUSH_LITERAL({:?})", s),
             #[cfg(feature = "grammar-extras")]
             Expr::NodeTag(expr, tag) => {
                 write!(f, "(#{} = {})", tag, expr)

--- a/meta/src/grammar.pest
+++ b/meta/src/grammar.pest
@@ -81,7 +81,7 @@ term = { node_tag? ~ prefix_operator* ~ node ~ postfix_operator* }
 node = _{ opening_paren ~ expression ~ closing_paren | terminal }
 
 /// A terminal expression.
-terminal = _{ _push | peek_slice | identifier | string | insensitive_string | range }
+terminal = _{ _push_literal | _push | peek_slice | identifier | string | insensitive_string | range }
 
 /// Possible predicates for a rule.
 prefix_operator = _{ positive_predicate_operator | negative_predicate_operator }
@@ -144,6 +144,9 @@ comma = { "," }
 
 /// A PUSH expression.
 _push = { "PUSH" ~ opening_paren ~ expression ~ closing_paren }
+
+/// A PUSH_LITERAL expression with one argument (and literal string).
+_push_literal = { "PUSH_LITERAL" ~ opening_paren ~ string ~ closing_paren }
 
 /// A PEEK expression.
 peek_slice = { "PEEK" ~ opening_brack ~ integer? ~ range_operator ~ integer? ~ closing_brack }

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -69,6 +69,7 @@ fn rule_to_optimized_rule(rule: Rule) -> OptimizedRule {
             Expr::Rep(expr) => OptimizedExpr::Rep(Box::new(to_optimized(*expr))),
             Expr::Skip(strings) => OptimizedExpr::Skip(strings),
             Expr::Push(expr) => OptimizedExpr::Push(Box::new(to_optimized(*expr))),
+            Expr::PushLiteral(string) => OptimizedExpr::PushLiteral(string),
             #[cfg(feature = "grammar-extras")]
             Expr::NodeTag(expr, tag) => OptimizedExpr::NodeTag(Box::new(to_optimized(*expr)), tag),
             #[cfg(feature = "grammar-extras")]
@@ -151,6 +152,8 @@ pub enum OptimizedExpr {
     Skip(Vec<String>),
     /// Matches an expression and pushes it to the stack, e.g. `push(e)`
     Push(Box<OptimizedExpr>),
+    /// Pushes a literal string to the stack, e.g. `push_literal("")`
+    PushLiteral(String),
     /// Matches an expression and assigns a label to it, e.g. #label = exp
     #[cfg(feature = "grammar-extras")]
     NodeTag(Box<OptimizedExpr>, String),
@@ -325,6 +328,7 @@ impl core::fmt::Display for OptimizedExpr {
                 write!(f, "(!({}) ~ ANY)*", strings)
             }
             OptimizedExpr::Push(expr) => write!(f, "PUSH({})", expr),
+            OptimizedExpr::PushLiteral(s) => write!(f, "PUSH_LITERAL({:?})", s),
             #[cfg(feature = "grammar-extras")]
             OptimizedExpr::NodeTag(expr, tag) => {
                 write!(f, "(#{} = {})", tag, expr)

--- a/meta/src/parser.rs
+++ b/meta/src/parser.rs
@@ -166,6 +166,8 @@ pub enum ParserExpr<'i> {
     RepMinMax(Box<ParserNode<'i>>, u32, u32),
     /// Matches an expression and pushes it to the stack, e.g. `push(e)`
     Push(Box<ParserNode<'i>>),
+    /// Pushes a literal string to the stack, e.g. `push_literal("a")`
+    PushLiteral(String),
     /// Matches an expression and assigns a label to it, e.g. #label = exp
     #[cfg(feature = "grammar-extras")]
     NodeTag(Box<ParserNode<'i>>, String),
@@ -204,6 +206,7 @@ fn convert_node(node: ParserNode<'_>) -> Expr {
             Expr::RepMinMax(Box::new(convert_node(*node)), min, max)
         }
         ParserExpr::Push(node) => Expr::Push(Box::new(convert_node(*node))),
+        ParserExpr::PushLiteral(string) => Expr::PushLiteral(string),
         #[cfg(feature = "grammar-extras")]
         ParserExpr::NodeTag(node, tag) => Expr::NodeTag(Box::new(convert_node(*node)), tag),
     }
@@ -227,6 +230,7 @@ pub fn rename_meta_rule(rule: &Rule) -> String {
     match *rule {
         Rule::grammar_rule => "rule".to_owned(),
         Rule::_push => "PUSH".to_owned(),
+        Rule::_push_literal => "PUSH_LITERAL".to_owned(),
         Rule::assignment_operator => "`=`".to_owned(),
         Rule::silent_modifier => "`_`".to_owned(),
         Rule::atomic_modifier => "`@`".to_owned(),
@@ -391,6 +395,16 @@ fn consume_expr<'i>(
                         ParserNode {
                             expr: ParserExpr::Push(Box::new(node)),
                             span: start.span(&end),
+                        }
+                    }
+                    Rule::_push_literal => {
+                        let mut pairs = pair.into_inner();
+                        pairs.next().unwrap(); // opening_paren
+                        let contents_pair = pairs.next().unwrap();
+                        let string = unescape(contents_pair.as_str()).expect("incorrect string literal");
+                        ParserNode {
+                            expr: ParserExpr::PushLiteral(string[1..string.len() - 1].to_owned()),
+                            span: contents_pair.clone().as_span(),
                         }
                     }
                     Rule::peek_slice => {
@@ -1316,6 +1330,7 @@ mod tests {
                 Rule::positive_predicate_operator,
                 Rule::negative_predicate_operator,
                 Rule::_push,
+                Rule::_push_literal,
                 Rule::peek_slice,
                 Rule::identifier,
                 Rule::insensitive_string,
@@ -1438,6 +1453,7 @@ mod tests {
                 Rule::positive_predicate_operator,
                 Rule::negative_predicate_operator,
                 Rule::_push,
+                Rule::_push_literal,
                 Rule::peek_slice,
                 Rule::identifier,
                 Rule::insensitive_string,

--- a/meta/src/validator.rs
+++ b/meta/src/validator.rs
@@ -400,6 +400,7 @@ fn is_non_progressing<'i>(
             min == 0 || is_non_progressing(&inner.expr, rules, trace)
         }
         ParserExpr::Push(ref inner) => is_non_progressing(&inner.expr, rules, trace),
+        ParserExpr::PushLiteral(_) => true,
         ParserExpr::RepOnce(ref inner) => is_non_progressing(&inner.expr, rules, trace),
         #[cfg(feature = "grammar-extras")]
         ParserExpr::NodeTag(ref inner, _) => is_non_progressing(&inner.expr, rules, trace),
@@ -494,6 +495,7 @@ fn is_non_failing<'i>(
         ParserExpr::Push(ref inner) | ParserExpr::PosPred(ref inner) => {
             is_non_failing(&inner.expr, rules, trace)
         }
+        ParserExpr::PushLiteral(_) => true,
         #[cfg(feature = "grammar-extras")]
         ParserExpr::NodeTag(ref inner, _) => is_non_failing(&inner.expr, rules, trace),
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -236,6 +236,7 @@ impl Vm {
                 })
             }),
             OptimizedExpr::Push(ref expr) => state.stack_push(|state| self.parse_expr(expr, state)),
+            OptimizedExpr::PushLiteral(ref string) => state.stack_push_literal(string.to_owned()),
             OptimizedExpr::Skip(ref strings) => state.skip_until(
                 &strings
                     .iter()


### PR DESCRIPTION
Add a rule `PUSH_LITERAL("a")`. This rule always matches and never consumes any input, and it pushes `"a"` to the stack. The argument must be a literal.

> [!note]
> I haven't added any unit tests or documentation yet; I wanted to get a sense of whether you'd be amenable to this new rule in principle, before I did that. But, I tested it locally on a grammar I have, and it does work.

This new rule accomplishes the goals of pest-parser/pest#880 (in a slightly different way). Instead of `PUSH_OTHER("-", " ")`, this is just `PUSH_LITERAL(" ")`. If you wanted to match A and then push B, you just combine them via a sequence: `"-" ~ PUSH_LITERAL(" ")`.

This can be used to generalize quoted strings to a pair of matching but non-equal delimiters. For example, many programming languages let you express strings using either double or single quotes, and don't require escaping of the other:

```
string = ${ PUSH( "\"" | "'") ~ quoted_char* ~ POP }
quoted_char = @{!PEEK ~ ANY } // simple version without escape sequences

// will parse "a'b" or 'a"b'
```

This happens to work because the starting and ending char are the same, but that's not always desirable. For example, we may want to allow strings to be delimited by either `(` ... `)` or `<` ... `>`, with similar rules as above, such that `(a>)` and `<a)>` are both valid.

With `PUSH_LITERAL`, this becomes:

```
string = ${ quote_open ~ quoted_char* ~ POP }
quote_open = @{
  ( "(" ~ PUSH_LITERAL(")") )
| ( "<" ~ PUSH_LITERAL(">") )
}
quoted_char = @{!PEEK ~ ANY } // simple version without escape sequences
```

Happy to hear your thoughts!