### PR TITLE
Add reference to ws2markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ You can find more projects and ecosystem tools in the [awesome-pest](https://git
 * [Melody](https://github.com/yoav-lavi/melody)
 * [json5-nodes](https://github.com/jlyonsmith/json5-nodes)
 * [prisma](https://github.com/prisma/prisma)
+* [ws2markdown](https://code.rosaelefanten.org/ws2markdown) (a WordStar to Markdown converter)
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
I like both pest and my small tool that wouldn't be possible without pest, so I thought I'd add it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added "ws2markdown" to the list of projects using pest in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->