### PR TITLE
bump the CI toolchain to 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           kind: check
-          toolchain: 1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+          toolchain: 1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: cargo check
         run: cargo check --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error --all-targets
 
@@ -40,7 +40,7 @@ jobs:
         with:
           kind: check
           components: clippy, rustfmt
-          toolchain: 1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+          toolchain: 1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
@@ -62,7 +62,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+          toolchain: 1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: cargo doc
         run: cargo doc --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error
 
@@ -79,7 +79,7 @@ jobs:
         with:
           kind: msrv
           tools: cargo-msrv
-          toolchain: 1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+          toolchain: 1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: Check msrv
         shell: sh
         run: for crate in "derive" "generator" "grammars" "meta" "pest" "vm"; do cd "$crate" && cargo msrv verify && cd ..; done
@@ -123,7 +123,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+          toolchain: 1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: Check feature powerset
         run: cargo hack check --feature-powerset --optional-deps --exclude-all-features --skip not-bootstrap-in-src,cargo --keep-going --lib --tests --ignore-private
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.81.0 # needed for `litemap v0.7.5` in pest_debugger
+        uses: dtolnay/rust-toolchain@1.82.0 # needed for `litemap v0.8.0` in pest_debugger
       - name: Bootstraping Grammars - Building
         run: cargo build --package pest_bootstrap
       - name: Bootstraping Grammars - Executing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflows to use Rust toolchain version 1.82.0.
  - Updated documentation comments to reflect the new litemap version requirement (v0.8.0) for pest_debugger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->