### PR TITLE
Fix a broken link to `Pair::as_span`

### DIFF
--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -18,7 +18,7 @@ use crate::position;
 /// A span over a `&str`. It is created from either [two `Position`s] or from a [`Pair`].
 ///
 /// [two `Position`s]: struct.Position.html#method.span
-/// [`Pair`]: ../iterators/struct.Pair.html#method.span
+/// [`Pair`]: ./iterators/struct.Pair.html#method.as_span
 #[derive(Clone, Copy)]
 pub struct Span<'i> {
     input: &'i str,


### PR DESCRIPTION
Noticed when reading https://docs.rs/pest/2.8.1/pest/struct.Span.html. I think this method was perhaps renamed at some point?

This seems to produce the right link at least locally, but I'm not 100%.