### PR TITLE
deps: drop `thiserror` for a manual impl

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -16,19 +16,18 @@ rust-version = "1.80"
 [features]
 default = ["std", "memchr"]
 # Implements `std::error::Error` for the `Error` type
-std = ["ucd-trie/std", "dep:thiserror"]
+std = ["ucd-trie/std"]
 # Enables the `to_json` function for `Pair` and `Pairs`
 pretty-print = ["dep:serde", "dep:serde_json"]
 # Enable const fn constructor for `PrecClimber`
 const_prec_climber = []
 # Enable miette error
-miette-error = ["std", "pretty-print", "dep:miette", "dep:thiserror"]
+miette-error = ["std", "pretty-print", "dep:miette"]
 
 [dependencies]
 ucd-trie = { version = "0.1.5", default-features = false }
 serde = { version = "1.0.145", optional = true }
 serde_json = { version = "1.0.85", optional = true }
-thiserror = { version = "2", optional = true }
 memchr = { version = "2", optional = true }
 miette = { version = "7.2.0", optional = true, features = ["fancy"] }
 


### PR DESCRIPTION
`thiserror` largely wasn't getting much use in `pest`, and it's a rather heavy dependency for an otherwise lightweight crate. The only other crate in the workspace that uses `thiserror` is `debugger` which doesn't seem worth trying to remove

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Reworked error handling to use explicit standard error trait implementations and clarify integrations between core and optional adapters.

- Chores
  - Removed an external error dependency and simplified feature flags to reduce configuration complexity.

- Performance
  - Potentially faster builds and smaller dependency footprint due to dependency and feature cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->