### PR TITLE
feat: impl Error from core

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pest", "parser", "peg", "grammar"]
 categories = ["parsing"]
 license = "MIT OR Apache-2.0"
 readme = "_README.md"
-rust-version = "1.80"
+rust-version = "1.81"
 
 [features]
 default = ["std", "memchr"]

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -42,7 +42,6 @@ pub struct Error<R> {
     parse_attempts: Option<ParseAttempts<R>>,
 }
 
-#[cfg(feature = "std")]
 impl<R: RuleType> core::error::Error for Error<R> {}
 
 /// Different kinds of parsing errors.
@@ -62,8 +61,7 @@ pub enum ErrorVariant<R> {
     },
 }
 
-#[cfg(feature = "std")]
-impl<R: RuleType> std::error::Error for ErrorVariant<R> {}
+impl<R: RuleType> core::error::Error for ErrorVariant<R> {}
 
 /// Where an `Error` has occurred.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -784,7 +782,7 @@ mod miette_adapter {
         }
     }
 
-    impl<R> std::error::Error for MietteAdapter<R>
+    impl<R> core::error::Error for MietteAdapter<R>
     where
         R: RuleType,
         Self: fmt::Debug + fmt::Display,


### PR DESCRIPTION
Followup to #1120. This switches to using `core::error::Error` and bumps the MSRV up to 1.81 to match. It looks like all of CI was already using at least 1.82, so I don't think that requires any additional changes