### PR TITLE
feat: add is_empty method to check if iterator contains no pairs

### DIFF
--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -374,6 +374,11 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         }
     }
 
+    /// Returns `true` if the iterator contains no `Pair`s.
+    pub fn is_empty(&self) -> bool {
+        self.pairs_count == 0
+    }
+
     /// Generates a string that stores the lexical information of `self` in
     /// a pretty-printed JSON format.
     #[cfg(feature = "pretty-print")]


### PR DESCRIPTION
is_empty is now mostly expected from various iterators - to the point that Clippy suggests adding it, and even AI [suggests](https://github.com/oxibus/can-dbc/pull/48#pullrequestreview-3379112653) it for pest despite pest code not supporting it.  So to make it more ergonomic, I think this helper would ... help :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `is_empty()` method for checking whether a collection contains any elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->