### PR TITLE
Fix newer clippy errors

### DIFF
--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -97,7 +97,7 @@ impl<'i, R: RuleType> FlatPairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> ExactSizeIterator for FlatPairs<'i, R> {
+impl<R: RuleType> ExactSizeIterator for FlatPairs<'_, R> {
     fn len(&self) -> usize {
         // Tokens len is exactly twice as flatten pairs len
         (self.end - self.start) >> 1
@@ -129,7 +129,7 @@ impl<'i, R: RuleType> Iterator for FlatPairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> DoubleEndedIterator for FlatPairs<'i, R> {
+impl<R: RuleType> DoubleEndedIterator for FlatPairs<'_, R> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.end <= self.start {
             return None;
@@ -148,7 +148,7 @@ impl<'i, R: RuleType> DoubleEndedIterator for FlatPairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> fmt::Debug for FlatPairs<'i, R> {
+impl<R: RuleType> fmt::Debug for FlatPairs<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlatPairs")
             .field("pairs", &self.clone().collect::<Vec<_>>())

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -324,7 +324,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> fmt::Debug for Pair<'i, R> {
+impl<R: RuleType> fmt::Debug for Pair<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let pair = &mut f.debug_struct("Pair");
         pair.field("rule", &self.as_rule());
@@ -338,7 +338,7 @@ impl<'i, R: RuleType> fmt::Debug for Pair<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> fmt::Display for Pair<'i, R> {
+impl<R: RuleType> fmt::Display for Pair<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let rule = self.as_rule();
         let start = self.pos(self.start);
@@ -371,7 +371,7 @@ impl<'i, R: PartialEq> PartialEq for Pair<'i, R> {
     }
 }
 
-impl<'i, R: Eq> Eq for Pair<'i, R> {}
+impl<R: Eq> Eq for Pair<'_, R> {}
 
 impl<'i, R: Hash> Hash for Pair<'i, R> {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -382,7 +382,7 @@ impl<'i, R: Hash> Hash for Pair<'i, R> {
 }
 
 #[cfg(feature = "pretty-print")]
-impl<'i, R: RuleType> ::serde::Serialize for Pair<'i, R> {
+impl<R: RuleType> ::serde::Serialize for Pair<'_, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -413,7 +413,7 @@ impl<'i, R: RuleType> Pairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> ExactSizeIterator for Pairs<'i, R> {
+impl<R: RuleType> ExactSizeIterator for Pairs<'_, R> {
     #[inline]
     fn len(&self) -> usize {
         self.pairs_count
@@ -437,7 +437,7 @@ impl<'i, R: RuleType> Iterator for Pairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> DoubleEndedIterator for Pairs<'i, R> {
+impl<R: RuleType> DoubleEndedIterator for Pairs<'_, R> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.end <= self.start {
             return None;
@@ -457,13 +457,13 @@ impl<'i, R: RuleType> DoubleEndedIterator for Pairs<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> fmt::Debug for Pairs<'i, R> {
+impl<R: RuleType> fmt::Debug for Pairs<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
-impl<'i, R: RuleType> fmt::Display for Pairs<'i, R> {
+impl<R: RuleType> fmt::Display for Pairs<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -485,7 +485,7 @@ impl<'i, R: PartialEq> PartialEq for Pairs<'i, R> {
     }
 }
 
-impl<'i, R: Eq> Eq for Pairs<'i, R> {}
+impl<R: Eq> Eq for Pairs<'_, R> {}
 
 impl<'i, R: Hash> Hash for Pairs<'i, R> {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -497,7 +497,7 @@ impl<'i, R: Hash> Hash for Pairs<'i, R> {
 }
 
 #[cfg(feature = "pretty-print")]
-impl<'i, R: RuleType> ::serde::Serialize for Pairs<'i, R> {
+impl<R: RuleType> ::serde::Serialize for Pairs<'_, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -84,7 +84,7 @@ impl<'i, R: RuleType> Tokens<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> ExactSizeIterator for Tokens<'i, R> {
+impl<R: RuleType> ExactSizeIterator for Tokens<'_, R> {
     fn len(&self) -> usize {
         self.end - self.start
     }
@@ -111,7 +111,7 @@ impl<'i, R: RuleType> Iterator for Tokens<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> DoubleEndedIterator for Tokens<'i, R> {
+impl<R: RuleType> DoubleEndedIterator for Tokens<'_, R> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.end <= self.start {
             return None;
@@ -125,7 +125,7 @@ impl<'i, R: RuleType> DoubleEndedIterator for Tokens<'i, R> {
     }
 }
 
-impl<'i, R: RuleType> fmt::Debug for Tokens<'i, R> {
+impl<R: RuleType> fmt::Debug for Tokens<'_, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -137,7 +137,7 @@ impl Default for CallLimitTracker {
 impl CallLimitTracker {
     fn limit_reached(&self) -> bool {
         self.current_call_limit
-            .map_or(false, |(current, limit)| current >= limit)
+            .is_some_and(|(current, limit)| current >= limit)
     }
 
     fn increment_depth(&mut self) {

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -441,7 +441,7 @@ impl<'i> Position<'i> {
     }
 }
 
-impl<'i> fmt::Debug for Position<'i> {
+impl fmt::Debug for Position<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Position").field("pos", &self.pos).finish()
     }
@@ -453,7 +453,7 @@ impl<'i> PartialEq for Position<'i> {
     }
 }
 
-impl<'i> Eq for Position<'i> {}
+impl Eq for Position<'_> {}
 
 #[allow(clippy::non_canonical_partial_ord_impl)]
 impl<'i> PartialOrd for Position<'i> {
@@ -473,7 +473,7 @@ impl<'i> Ord for Position<'i> {
     }
 }
 
-impl<'i> Hash for Position<'i> {
+impl Hash for Position<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.input as *const str).hash(state);
         self.pos.hash(state);

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -270,7 +270,7 @@ impl<'i> Span<'i> {
     }
 }
 
-impl<'i> fmt::Debug for Span<'i> {
+impl fmt::Debug for Span<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Span")
             .field("str", &self.as_str())
@@ -286,9 +286,9 @@ impl<'i> PartialEq for Span<'i> {
     }
 }
 
-impl<'i> Eq for Span<'i> {}
+impl Eq for Span<'_> {}
 
-impl<'i> Hash for Span<'i> {
+impl Hash for Span<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.input as *const str).hash(state);
         self.start.hash(state);


### PR DESCRIPTION
These are mostly more lifetime elisions, and `Option::is_some_and(f)` replacing `Option::map(false, f)`, see: https://github.com/pest-parser/pest/actions/runs/18968907018/job/54188036314

Fixes CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Generalized internal lifetime parameters across iterator and utility types, broadening their applicability without changing observable behavior.
  * Simplified method signature handling to improve code maintainability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->