### PR TITLE
fix(macro): resolve parses_to! compiler errors in integration tests

### DIFF
--- a/pest/src/macros.rs
+++ b/pest/src/macros.rs
@@ -191,9 +191,8 @@ macro_rules! consumes_to {
 macro_rules! parses_to {
     ( parser: $parser:ident, input: $string:expr, rule: $rules:tt :: $rule:tt,
       tokens: [ $( $names:ident $calls:tt ),* $(,)* ] ) => {
-
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             use $crate::Parser;
 
             let mut tokens = $parser::parse($rules::$rule, $string).unwrap().tokens();
@@ -289,8 +288,8 @@ macro_rules! parses_to {
 macro_rules! fails_with {
     ( parser: $parser:ident, input: $string:expr, rule: $rules:tt :: $rule:tt,
       positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             use $crate::Parser;
 
             let error = $parser::parse($rules::$rule, $string).unwrap_err();

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -132,9 +132,8 @@ macro_rules! consumes_to {
 macro_rules! parses_to {
     ( parser: $parser:expr, input: $string:expr, rule: $rule:expr,
       tokens: [ $( $names:ident $calls:tt ),* $(,)* ] ) => {
-
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             let vm = $parser;
             let mut tokens = vm.parse($rule, $string).unwrap().tokens();
 
@@ -177,9 +176,9 @@ macro_rules! parses_to {
 macro_rules! fails_with {
     ( parser: $parser:expr, input: $string:expr, rule: $rule:expr,
       positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        #[allow(unused_mut)]
-        #[allow(unused_variables)]
         {
+            #![allow(unused_mut)]
+            #![allow(unused_variables)]
             let vm = $parser;
             let error = vm.parse($rule, $string).unwrap_err();
 


### PR DESCRIPTION
## Problem

The \parses_to!\ and \ails_with!\ macros produce compiler errors when used in integration test files (files under \	ests/\ directory):

- Without semicolon: \expected item after attributes\
- With semicolon: \expected item, found \;\\

Closes #1107

## Root Cause

Both macros expand to \#[allow(unused_mut)] { ... }\ — an outer attribute on a block expression. This requires the unstable \stmt_expr_attributes\ nightly feature. When used as a statement in integration tests, the compiler interprets the \#[allow(...)]\ as an outer attribute on the next item rather than on the block, causing the error.

## Fix

Replace outer attributes with inner attributes inside the block:

\\\ust
// Before (requires unstable feature)
#[allow(unused_mut)]
{
    ...
}

// After (stable, works everywhere)
{
    #![allow(unused_mut)]
    ...
}
\\\

This change is applied to both \parses_to!\ and \ails_with!\ in \pest/src/macros.rs\ and \m/src/macros.rs\.

## Testing

The existing tests in \pest/src/macros.rs\ (the \parses_to\ and \ails_with\ test module) continue to use these macros and validate the fix.

## Changes

- \pest/src/macros.rs\: \parses_to!\ and \ails_with!\ — outer to inner attributes
- \m/src/macros.rs\: \parses_to!\ and \ails_with!\ — outer to inner attributes