### PR TITLE
fix(test): make miette_error test independent of terminal

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -1181,6 +1181,9 @@ mod tests {
     #[cfg(feature = "miette-error")]
     #[test]
     fn miette_error() {
+        // Force color output so the test passes regardless of TTY availability
+        std::env::set_var("FORCE_COLOR", "1");
+
         let input = "abc\ndef";
         let pos = Position::new(input, 4).unwrap();
         let error: Error<u32> = Error::new_from_pos(

--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -1182,6 +1182,7 @@ mod tests {
     #[test]
     fn miette_error() {
         // Force color output so the test passes regardless of TTY availability
+        let prev_force_color = std::env::var_os("FORCE_COLOR");
         std::env::set_var("FORCE_COLOR", "1");
 
         let input = "abc\ndef";
@@ -1209,5 +1210,12 @@ mod tests {
             ]
             .join("\n")
         );
+
+        // Restore previous FORCE_COLOR state to avoid cross-test leakage
+        if let Some(prev) = prev_force_color {
+            std::env::set_var("FORCE_COLOR", prev);
+        } else {
+            std::env::remove_var("FORCE_COLOR");
+        }
     }
 }


### PR DESCRIPTION
The `miette_error` test hardcodes ANSI escape sequences in expected output, but miette only emits colors when a TTY is detected. This causes the test to fail in non-interactive environments (Debian build systems, CI without TTY).

Set `FORCE_COLOR=1` to ensure consistent color output regardless of terminal availability.

Fixes #1139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made error-display tests deterministic by temporarily enabling colored output, reading any existing color setting, and restoring or removing it afterward to avoid environment leakage and ensure consistent, repeatable error-formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->