### PR TITLE
bump default CI toolchain to 1.86

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
   toolchain:
     description: Toolchain version
     required: false
-    default: "1.85.0"
+    default: "1.86.0"
   components:
     description: Toolchain components
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           kind: check
-          toolchain: 1.85.0 # needed for the `clap_lex` crates in pest_debugger
+          toolchain: 1.86.0 # needed for the `icu_*` crates in pest_debugger
       - name: cargo check
         run: cargo check --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error --all-targets
 
@@ -40,7 +40,7 @@ jobs:
         with:
           kind: check
           components: clippy, rustfmt
-          toolchain: 1.85.0 # needed for the `clap_lex` crates in pest_debugger
+          toolchain: 1.86.0 # needed for the `icu_*` crates in pest_debugger
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
@@ -79,7 +79,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.85.0 # needed for the `clap_lex` crates in pest_debugger
+          toolchain: 1.86.0 # needed for the `icu_*` crates in pest_debugger
       - name: cargo doc
         run: cargo doc --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error
 
@@ -96,7 +96,7 @@ jobs:
         with:
           kind: msrv
           tools: cargo-msrv
-          toolchain: 1.85.0 # needed for the `clap_lex` crates in pest_debugger
+          toolchain: 1.86.0 # needed for the `icu_*` crates in pest_debugger
       - name: Check msrv
         shell: sh
         run: for crate in "derive" "generator" "grammars" "meta" "pest" "vm"; do cd "$crate" && cargo minimal-versions check && cd ..; done
@@ -140,7 +140,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: 1.85.0 # needed for the `clap_lex` crates in pest_debugger
+          toolchain: 1.86.0 # needed for the `icu_*` crates in pest_debugger
       - name: Check feature powerset
         run: cargo hack check --feature-powerset --optional-deps --exclude-all-features --keep-going --lib --tests --ignore-private
 

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -12,6 +12,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/pest-parser/pest/master/pest-logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#[allow(clippy::doc_overindented_list_items)]
 //! # pest. The Elegant Parser
 //!
 //! pest is a general purpose parser written in Rust with a focus on accessibility, correctness,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust compiler toolchain to 1.86.0 in the CI build pipeline.
  * Suppressed a documentation lint to reduce spurious warnings during checks and documentation builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->