### PR TITLE
fix doc indentation check

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -12,6 +12,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/pest-parser/pest/master/pest-logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![allow(clippy::doc_overindented_list_items)]
 //! # pest. The Elegant Parser
 //!
 //! pest is a general purpose parser written in Rust with a focus on accessibility, correctness,

--- a/pest/benches/stack.rs
+++ b/pest/benches/stack.rs
@@ -55,14 +55,14 @@ fn snapshot_pop_clear<T: Clone>(elements: impl Iterator<Item = T>) {
 }
 
 fn benchmark(b: &mut Criterion) {
-    use core::iter::repeat;
+    use core::iter::repeat_n;
     // use criterion::black_box;
     let times = 10000usize;
     let small = 0..times;
     let medium = ("", 0usize, 1usize);
-    let medium = repeat(medium).take(times);
+    let medium = repeat_n(medium, times);
     let large = [""; 64];
-    let large = repeat(large).take(times);
+    let large = repeat_n(large, times);
     macro_rules! test_series {
         ($kind:ident) => {
             b.bench_function(stringify!(push - restore - $kind), |b| {

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -12,7 +12,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/pest-parser/pest/master/pest-logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#[allow(clippy::doc_overindented_list_items)]
+#![allow(clippy::doc_overindented_list_items)]
 //! # pest. The Elegant Parser
 //!
 //! pest is a general purpose parser written in Rust with a focus on accessibility, correctness,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated crate-level lint configuration to suppress specific documentation indentation warnings.
  * Cleaned up benchmark iterator construction for clearer, fixed-length repetition in performance tests.

Note: Internal maintenance only; no functional or behavioral changes visible to end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->