### PR TITLE
docs: add Panics sections to line_col() and PrattParser::parse()

### DIFF
--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -111,6 +111,10 @@ impl<'i> Position<'i> {
     /// This is an O(n) operation, where n is the number of chars in the input.
     /// You better use [`pair.line_col()`](struct.Pair.html#method.line_col) instead.
     ///
+    /// # Panics
+    ///
+    /// Panics if the position is out of bounds.
+    ///
     /// # Examples
     ///
     /// ```

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -312,6 +312,12 @@ where
     /// parser (previously defined using [`map_primary`], [`map_prefix`], [`map_postfix`],
     /// and [`map_infix`] methods).
     ///
+    /// # Panics
+    ///
+    /// Panics if the input pairs contain a prefix operator with no [`map_prefix`],
+    /// an infix operator with no [`map_infix`], a postfix operator with no [`map_postfix`],
+    /// or an unexpected token that is not a valid prefix, primary, infix, or postfix expression.
+    ///
     /// [`map_primary`]: struct.PrattParser.html#method.map_primary
     /// [`map_prefix`]: struct.PrattParserMap.html#method.map_prefix
     /// [`map_postfix`]: struct.PrattParserMap.html#method.map_postfix


### PR DESCRIPTION
Two public functions that can panic were missing # Panics documentation:

- Position::line_col() panics when the position is out of bounds
- PrattParser::parse() panics when mappers are missing for operator types or unexpected tokens are encountered

Addresses #999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated library API documentation to clarify edge case behaviors and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->