### PR TITLE
test(position): add should_panic tests for documented panic conditions

### DIFF
--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -659,4 +659,31 @@ mod tests {
 
         positions.insert(start);
     }
+
+    #[test]
+    #[should_panic(expected = "span created from positions from different inputs")]
+    fn span_panic_different_inputs() {
+        let input1 = "a";
+        let input2 = "b";
+        let pos1 = Position::from_start(input1);
+        let pos2 = Position::from_start(input2);
+
+        pos1.span(&pos2);
+    }
+
+    #[test]
+    #[should_panic(expected = "position out of bounds")]
+    fn line_col_panic_out_of_bounds() {
+        let input = "ab";
+        let pos = Position::new_internal(input, 5);
+        pos.line_col();
+    }
+
+    #[test]
+    #[should_panic(expected = "position out of bounds")]
+    fn line_of_panic_out_of_bounds() {
+        let input = "ab";
+        let pos = Position::new_internal(input, 5);
+        pos.line_of();
+    }
 }


### PR DESCRIPTION
Three panic conditions in \Position\ were documented but had no tests:

- \span()\ panics when positions come from different inputs
- \line_col()\ panics when position is out of bounds
- \line_of()\ panics when position is out of bounds

Added \#[should_panic]\ tests for each. The out-of-bounds tests use \
ew_internal\ to construct invalid positions since the public \Position::new()\ validates bounds.

Related to #999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for boundary validation in position handling, ensuring robustness of error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->