### PR TITLE
Document panics in public API

### DIFF
--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -1513,6 +1513,10 @@ impl<'i, R: RuleType> ParserState<'i, R> {
     /// Peeks the top of the stack and attempts to match the string. Returns `Ok(Box<ParserState>)`
     /// if the string is matched successfully, or `Err(Box<ParserState>)` otherwise.
     ///
+    /// # Panics
+    ///
+    /// Panics if the stack is empty.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1541,6 +1545,10 @@ impl<'i, R: RuleType> ParserState<'i, R> {
 
     /// Pops the top of the stack and attempts to match the string. Returns `Ok(Box<ParserState>)`
     /// if the string is matched successfully, or `Err(Box<ParserState>)` otherwise.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stack is empty.
     ///
     /// # Examples
     ///

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -175,6 +175,10 @@ impl<'i> Position<'i> {
 
     /// Returns the entire line of the input that contains this `Position`.
     ///
+    /// # Panics
+    ///
+    /// Panics if the position is out of bounds (e.g., beyond the end of the input).
+    ///
     /// # Examples
     ///
     /// ```
@@ -470,6 +474,9 @@ impl<'i> PartialOrd for Position<'i> {
     }
 }
 
+/// # Panics
+///
+/// Panics when comparing positions from different input strings.
 impl<'i> Ord for Position<'i> {
     fn cmp(&self, other: &Position<'i>) -> Ordering {
         self.partial_cmp(other)


### PR DESCRIPTION
Add missing `# Panics` sections to:

- `Position::line_of()` - panics when position is out of bounds
- `ParserState::stack_peek()` - panics when called on empty stack
- `ParserState::stack_pop()` - panics when called on empty stack
- `Position::Ord::cmp()` - panics when comparing positions from different input strings

Fixes #999

---Payment info---
PayPal: n6085530@gmail.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified panic conditions for stack operations to help users understand when the stack is empty.
  * Enhanced documentation for position operations to document panic conditions when positions are out of bounds or when comparing positions from different input strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->