### PR TITLE
ci: bump nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           kind: check
           components: rust-src
-          toolchain: nightly-2026-01-20 # upgrade this regularly
+          toolchain: nightly-2026-06-20 # upgrade this regularly
       - name: check no_std compatibility
         run: cd pest && cargo build -j1 -Z build-std=core,alloc --no-default-features --target x86_64-unknown-linux-gnu
 
@@ -173,7 +173,7 @@ jobs:
         id: setup
         with:
           kind: check
-          toolchain: nightly-2026-01-20
+          toolchain: nightly-2026-06-20
           tools: cargo-semver-checks
       - name: check semver compatibility
         shell: bash

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = [
     "Dragoș Tiselice <dragostiselice@gmail.com>",
@@ -17,9 +17,9 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.8.6" }
-pest_meta = { path = "../meta", version = "2.8.6" }
-pest_vm = { path = "../vm", version = "2.8.6" }
+pest = { path = "../pest", version = "2.8.7" }
+pest_meta = { path = "../meta", version = "2.8.7" }
+pest_vm = { path = "../vm", version = "2.8.7" }
 reqwest = { version = "= 0.11.13", default-features = false, features = [
     "blocking",
     "json",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -24,5 +24,5 @@ grammar-extras = ["pest_generator/grammar-extras"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.8.6", default-features = false }
-pest_generator = { path = "../generator", version = "2.8.6", default-features = false }
+pest = { path = "../pest", version = "2.8.7", default-features = false }
+pest_generator = { path = "../generator", version = "2.8.7", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -21,8 +21,8 @@ grammar-extras = ["pest_meta/grammar-extras"]
 export-internal = []
 
 [dependencies]
-pest = { path = "../pest", version = "2.8.6", default-features = false }
-pest_meta = { path = "../meta", version = "2.8.6" }
+pest = { path = "../pest", version = "2.8.7", default-features = false }
+pest_meta = { path = "../meta", version = "2.8.7" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.8.6" }
-pest_derive = { path = "../derive", version = "2.8.6" }
+pest = { path = "../pest", version = "2.8.7" }
+pest_derive = { path = "../derive", version = "2.8.7" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -21,7 +21,7 @@ include = [
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.8.6" }
+pest = { path = "../pest", version = "2.8.7" }
 
 [features]
 default = []

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"

--- a/pest/src/macros.rs
+++ b/pest/src/macros.rs
@@ -191,9 +191,8 @@ macro_rules! consumes_to {
 macro_rules! parses_to {
     ( parser: $parser:ident, input: $string:expr, rule: $rules:tt :: $rule:tt,
       tokens: [ $( $names:ident $calls:tt ),* $(,)* ] ) => {
-
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             use $crate::Parser;
 
             let mut tokens = $parser::parse($rules::$rule, $string).unwrap().tokens();
@@ -289,8 +288,8 @@ macro_rules! parses_to {
 macro_rules! fails_with {
     ( parser: $parser:ident, input: $string:expr, rule: $rules:tt :: $rule:tt,
       positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             use $crate::Parser;
 
             let error = $parser::parse($rules::$rule, $string).unwrap_err();

--- a/pest/src/macros.rs
+++ b/pest/src/macros.rs
@@ -287,30 +287,28 @@ macro_rules! parses_to {
 #[macro_export]
 macro_rules! fails_with {
     ( parser: $parser:ident, input: $string:expr, rule: $rules:tt :: $rule:tt,
-      positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        {
-            #![allow(unused_mut)]
-            use $crate::Parser;
+      positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {{
+        #![allow(unused_mut)]
+        use $crate::Parser;
 
-            let error = $parser::parse($rules::$rule, $string).unwrap_err();
+        let error = $parser::parse($rules::$rule, $string).unwrap_err();
 
-            match error.variant {
-                $crate::error::ErrorVariant::ParsingError {
-                    positives,
-                    negatives,
-                } => {
-                    assert_eq!(positives, $positives, "positives");
-                    assert_eq!(negatives, $negatives, "negatives");
-                }
-                _ => unreachable!(),
-            };
-
-            match error.location {
-                $crate::error::InputLocation::Pos(pos) => assert_eq!(pos, $pos, "pos"),
-                _ => unreachable!(),
+        match error.variant {
+            $crate::error::ErrorVariant::ParsingError {
+                positives,
+                negatives,
+            } => {
+                assert_eq!(positives, $positives, "positives");
+                assert_eq!(negatives, $negatives, "negatives");
             }
+            _ => unreachable!(),
+        };
+
+        match error.location {
+            $crate::error::InputLocation::Pos(pos) => assert_eq!(pos, $pos, "pos"),
+            _ => unreachable!(),
         }
-    };
+    }};
 }
 
 #[cfg(test)]

--- a/semvercheck.sh
+++ b/semvercheck.sh
@@ -8,7 +8,7 @@ cargo run --package pest_bootstrap
 
 # current
 for crate in "pest_derive" "pest_generator" "pest_grammars" "pest_meta" "pest" "pest_vm" "pest_debugger"; do
-    cargo +nightly-2025-08-20 rustdoc -p $crate -- $RUSTDOC_LATE_FLAGS
+    cargo +nightly-2026-06-20 rustdoc -p $crate -- $RUSTDOC_LATE_FLAGS
     mv target/doc/$crate.json /tmp/current-$crate.json
 done
 
@@ -21,7 +21,7 @@ cargo clean
 cargo build --package pest_bootstrap
 cargo run --package pest_bootstrap
 for crate in "pest_derive" "pest_generator" "pest_grammars" "pest_meta" "pest" "pest_vm" "pest_debugger"; do
-    cargo +nightly-2025-08-20 rustdoc -p $crate -- $RUSTDOC_LATE_FLAGS
+    cargo +nightly-2026-06-20 rustdoc -p $crate -- $RUSTDOC_LATE_FLAGS
     mv target/doc/$crate.json /tmp/baseline-$crate.json
     echo "Checking $crate"
     cargo semver-checks check-release --current /tmp/current-$crate.json --baseline /tmp/baseline-$crate.json

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.8.6"
+version = "2.8.7"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.8.6" }
-pest_meta = { path = "../meta", version = "2.8.6" }
+pest = { path = "../pest", version = "2.8.7" }
+pest_meta = { path = "../meta", version = "2.8.7" }
 
 [features]
 grammar-extras = ["pest_meta/grammar-extras"]

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -132,9 +132,8 @@ macro_rules! consumes_to {
 macro_rules! parses_to {
     ( parser: $parser:expr, input: $string:expr, rule: $rule:expr,
       tokens: [ $( $names:ident $calls:tt ),* $(,)* ] ) => {
-
-        #[allow(unused_mut)]
         {
+            #![allow(unused_mut)]
             let vm = $parser;
             let mut tokens = vm.parse($rule, $string).unwrap().tokens();
 
@@ -177,9 +176,9 @@ macro_rules! parses_to {
 macro_rules! fails_with {
     ( parser: $parser:expr, input: $string:expr, rule: $rule:expr,
       positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        #[allow(unused_mut)]
-        #[allow(unused_variables)]
         {
+            #![allow(unused_mut)]
+            #![allow(unused_variables)]
             let vm = $parser;
             let error = vm.parse($rule, $string).unwrap_err();
 

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -175,31 +175,29 @@ macro_rules! parses_to {
 #[macro_export]
 macro_rules! fails_with {
     ( parser: $parser:expr, input: $string:expr, rule: $rule:expr,
-      positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {
-        {
-            #![allow(unused_mut)]
-            #![allow(unused_variables)]
-            let vm = $parser;
-            let error = vm.parse($rule, $string).unwrap_err();
+      positives: $positives:expr, negatives: $negatives:expr, pos: $pos:expr ) => {{
+        #![allow(unused_mut)]
+        #![allow(unused_variables)]
+        let vm = $parser;
+        let error = vm.parse($rule, $string).unwrap_err();
 
-            match error.variant {
-                ::pest::error::ErrorVariant::ParsingError {
-                    positives,
-                    negatives,
-                } => {
-                    let quoted_positives: Vec<&str> = $positives;
-                    let quoted_negatives: Vec<&str> = $negatives;
+        match error.variant {
+            ::pest::error::ErrorVariant::ParsingError {
+                positives,
+                negatives,
+            } => {
+                let quoted_positives: Vec<&str> = $positives;
+                let quoted_negatives: Vec<&str> = $negatives;
 
-                    assert_eq!(quoted_positives, positives);
-                    assert_eq!(quoted_negatives, negatives);
-                }
-                _ => unreachable!(),
-            };
-
-            match error.location {
-                ::pest::error::InputLocation::Pos(pos) => assert_eq!(pos, $pos),
-                _ => unreachable!(),
+                assert_eq!(quoted_positives, positives);
+                assert_eq!(quoted_negatives, negatives);
             }
+            _ => unreachable!(),
+        };
+
+        match error.location {
+            ::pest::error::InputLocation::Pos(pos) => assert_eq!(pos, $pos),
+            _ => unreachable!(),
         }
-    };
+    }};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped crate version numbers across the workspace from `2.8.6` to `2.8.7` (including core and supporting crates).
  * Refreshed the Rust nightly toolchains used for compatibility CI and semver baseline generation.
  * Improved warning suppression within generated parser-related macro expansions to keep builds warning-clean, without changing macro behavior or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->