### PR TITLE
fix: restore stack state after a failed sequence

### DIFF
--- a/derive/tests/grammar.pest
+++ b/derive/tests/grammar.pest
@@ -49,6 +49,7 @@ peek_slice_23 = { PUSH(range) ~ PUSH(range) ~ PUSH(range) ~ PUSH(range) ~ PUSH(r
 pop_ = { PUSH(range) ~ PUSH(range) ~ POP ~ POP }
 pop_all = { PUSH(range) ~ PUSH(range) ~ POP_ALL }
 pop_fail = { PUSH(range) ~ !POP ~ range ~ POP }
+clear_nested_snapshot = { PUSH("a") ~ ( POP? ~ "X" )? ~ POP ~ EOI }
 checkpoint_restore = ${
 		PUSH("") ~ (PUSH("a") ~ "b" ~ POP | DROP ~ "b" | POP ~ "a") ~ EOI
 }

--- a/derive/tests/grammar.rs
+++ b/derive/tests/grammar.rs
@@ -867,6 +867,18 @@ fn checkpoint_restore() {
 }
 
 #[test]
+fn clear_nested_snapshot() {
+    parses_to! {
+        parser: GrammarParser,
+        input: "aa",
+        rule: Rule::clear_nested_snapshot,
+        tokens: [
+            clear_nested_snapshot(0, 2, [EOI(2, 2)])
+        ]
+    };
+}
+
+#[test]
 fn ascii_digits() {
     parses_to! {
         parser: GrammarParser,

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -917,15 +917,15 @@ impl<'i, R: RuleType> ParserState<'i, R> {
         let token_index = self.queue.len();
         let initial_pos = self.position;
 
-        let result = f(self);
+        let result = f(self.checkpoint());
 
         match result {
-            Ok(new_state) => Ok(new_state),
+            Ok(new_state) => Ok(new_state.checkpoint_ok()),
             Err(mut new_state) => {
                 // Restore the initial position and truncate the token queue.
                 new_state.position = initial_pos;
                 new_state.queue.truncate(token_index);
-                Err(new_state)
+                Err(new_state.restore())
             }
         }
     }

--- a/pest/src/stack.rs
+++ b/pest/src/stack.rs
@@ -100,9 +100,21 @@ impl<T: Clone> Stack<T> {
 
     /// The parsing after the last snapshot was successful so clearing it.
     pub fn clear_snapshot(&mut self) {
-        if let Some((len, unpopped)) = self.lengths.pop() {
-            // Popped elements from previous state are no longer needed.
-            self.popped.truncate(self.popped.len() - (len - unpopped));
+        if let Some((len, remained)) = self.lengths.pop() {
+            let popped_count = len - remained;
+            if let Some((_, parent_remained)) = self.lengths.last_mut() {
+                let merged_remained = (*parent_remained).min(remained);
+                let parent_popped = *parent_remained - merged_remained;
+                *parent_remained = merged_remained;
+
+                let popped_start = self.popped.len() - popped_count;
+                drop(
+                    self.popped
+                        .drain(popped_start..popped_start + popped_count - parent_popped),
+                );
+            } else {
+                self.popped.truncate(self.popped.len() - popped_count);
+            }
         }
     }
 
@@ -242,6 +254,35 @@ mod test {
         stack.snapshot();
         stack.pop();
         stack.clear_snapshot();
+
+        assert_eq!(stack[0..stack.len()], [0]);
+    }
+
+    #[test]
+    fn nested_snapshot_pop_clear_restore() {
+        let mut stack = Stack::new();
+
+        stack.push(0);
+        stack.snapshot();
+        stack.snapshot();
+        stack.pop();
+        stack.clear_snapshot();
+        stack.restore();
+
+        assert_eq!(stack[0..stack.len()], [0]);
+    }
+
+    #[test]
+    fn nested_snapshot_clear_preserves_outer_boundary() {
+        let mut stack = Stack::new();
+
+        stack.push(0);
+        stack.snapshot();
+        stack.push(1);
+        stack.snapshot();
+        stack.pop();
+        stack.clear_snapshot();
+        stack.restore();
 
         assert_eq!(stack[0..stack.len()], [0]);
     }


### PR DESCRIPTION
Fixes #1183.

## Summary

- restore stack state when a parser sequence fails
- retain values needed by an outer snapshot when clearing an inner snapshot
- add direct `Stack` and `pest_derive` grammar regressions

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-A mismatched_lifetime_syntaxes" cargo clippy --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error --all-targets -- -Dwarnings`
- `cargo test --all --features pretty-print,const_prec_climber,memchr,grammar-extras,miette-error --release`
- `cargo test -p pest_grammars --lib --verbose --release -- --ignored tests::toml_handles_deep_nesting_unstable`
- production-only revert: both new regressions failed with the fix reverted and passed again after restoration

The Clippy suppression is limited to the pre-existing `mismatched_lifetime_syntaxes` warning introduced by the host Rust 1.93 toolchain; upstream CI pins Rust 1.86.

## AI assistance

I used Codex during implementation and test design, then reviewed the final diff and reran the reported checks in a clean isolated checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser backtracking to correctly restore stack state when sequence parsing fails.
  * Fixed nested snapshot clearing and restoration behavior, preserving outer snapshot boundaries.
* **Tests**
  * Added coverage for nested snapshots, optional pops, clearing behavior, and restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->