### PR TITLE
Add support for a fully-functional const PrattParser with optional macro for increased ergonomics

### DIFF
--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -38,3 +38,7 @@ miette = { version = "7.2.0", features = ["fancy"] }
 [[bench]]
 name = "stack"
 harness = false
+
+[[bench]]
+name = "pratt"
+harness = false

--- a/pest/benches/pratt.rs
+++ b/pest/benches/pratt.rs
@@ -88,7 +88,7 @@ fn build_runtime() -> PrattParser<Rule> {
 }
 
 fn build_const() -> ConstPrattParser<Rule, 30> {
-    ConstPrattParser::new_const(from_fn(|i| (Op::infix(RULES[i], Assoc::Left), 0)))
+    ConstPrattParser::new_const(from_fn(|i| (Op::infix(RULES[i], Assoc::Left), true)))
 }
 
 fn benchmark(b: &mut Criterion) {

--- a/pest/benches/pratt.rs
+++ b/pest/benches/pratt.rs
@@ -1,0 +1,119 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pest::pratt_parser::{Affix, Assoc, ConstPrattParser, Op, PrattParser, PrattParserOps};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum Rule {
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+    A8,
+    A9,
+    B0,
+    B1,
+    B2,
+    B3,
+    B4,
+    B5,
+    B6,
+    B7,
+    B8,
+    B9,
+    C0,
+    C1,
+    C2,
+    C3,
+    C4,
+    C5,
+    C6,
+    C7,
+    C8,
+    C9,
+}
+
+const RULES: &[Rule] = &[
+    Rule::A0,
+    Rule::A1,
+    Rule::A2,
+    Rule::A3,
+    Rule::A4,
+    Rule::A5,
+    Rule::A6,
+    Rule::A7,
+    Rule::A8,
+    Rule::A9,
+    Rule::B0,
+    Rule::B1,
+    Rule::B2,
+    Rule::B3,
+    Rule::B4,
+    Rule::B5,
+    Rule::B6,
+    Rule::B7,
+    Rule::B8,
+    Rule::B9,
+    Rule::C0,
+    Rule::C1,
+    Rule::C2,
+    Rule::C3,
+    Rule::C4,
+    Rule::C5,
+    Rule::C6,
+    Rule::C7,
+    Rule::C8,
+    Rule::C9,
+];
+
+fn build_runtime() -> PrattParser<Rule> {
+    let mut parser = PrattParser::new();
+    for &rule in RULES {
+        parser = parser.op(Op::infix(rule, Assoc::Left));
+    }
+    parser
+}
+
+fn build_const() -> ConstPrattParser<Rule> {
+    let mut ops = Vec::new();
+    for (i, &rule) in RULES.iter().enumerate() {
+        ops.push((rule, Affix::Infix(Assoc::Left), (i as u32) + 1));
+    }
+    let ops: &'static [(Rule, Affix, u32)] = Box::leak(ops.into_boxed_slice());
+    ConstPrattParser::new_const(ops)
+}
+
+fn benchmark(b: &mut Criterion) {
+    let runtime = build_runtime();
+    let const_ = build_const();
+
+    b.bench_function("pratt_runtime_lookup", |b| {
+        b.iter(|| {
+            for &rule in RULES {
+                black_box(runtime.get(&rule));
+            }
+        })
+    });
+
+    b.bench_function("pratt_const_lookup", |b| {
+        b.iter(|| {
+            for &rule in RULES {
+                black_box(const_.get(&rule));
+            }
+        })
+    });
+}
+
+criterion_group!(benchmarks, benchmark);
+criterion_main!(benchmarks);

--- a/pest/benches/pratt.rs
+++ b/pest/benches/pratt.rs
@@ -7,8 +7,10 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use std::array::from_fn;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pest::pratt_parser::{Affix, Assoc, ConstPrattParser, Op, PrattParser, PrattParserOps};
+use pest::pratt_parser::{Assoc, ConstPrattParser, Op, PrattParser, PrattParserOps};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 enum Rule {
@@ -85,13 +87,8 @@ fn build_runtime() -> PrattParser<Rule> {
     parser
 }
 
-fn build_const() -> ConstPrattParser<Rule> {
-    let mut ops = Vec::new();
-    for (i, &rule) in RULES.iter().enumerate() {
-        ops.push((rule, Affix::Infix(Assoc::Left), (i as u32) + 1));
-    }
-    let ops: &'static [(Rule, Affix, u32)] = Box::leak(ops.into_boxed_slice());
-    ConstPrattParser::new_const(ops)
+fn build_const() -> ConstPrattParser<Rule, 30> {
+    ConstPrattParser::new_const(from_fn(|i| (Op::infix(RULES[i], Assoc::Left), 0)))
 }
 
 fn benchmark(b: &mut Criterion) {

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -300,13 +300,14 @@ pub struct ConstPrattParser<R: RuleType + 'static, const N: usize> {
 }
 
 impl<R: RuleType + 'static, const N: usize> ConstPrattParser<R, N> {
-    /// Create a `ConstPrattParser` from a static array of (`[`Op`]`, `u8`)
+    /// Create a `ConstPrattParser` from a static array of (`[`Op`]`, `bool`)
     /// pairs.
     ///
-    /// Just like [`PrattParser::op`], but for use in a `const` context. The `u8`
-    /// in each pair is a precedence delta relative to the previous operator:
-    /// use `0` to keep the same precedence, and `1` (or higher) to move to the
-    /// next precedence level. The first delta must be `0`.
+    /// Just like [`PrattParser::op`], but for use in a `const` context. The
+    /// `bool` in each pair tells whether the operator starts a new precedence
+    /// level (`true`) or shares the previous operator's level (`false`).
+    /// Levels are ordered from lowest to highest precedence; the first
+    /// operator must start a new level (`true`).
     ///
     /// # Example
     ///
@@ -315,22 +316,37 @@ impl<R: RuleType + 'static, const N: usize> ConstPrattParser<R, N> {
     /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     /// # enum Rule { expr, int, add, sub, mul, div, pow, neg, fac }
     /// static PRATT: ConstPrattParser<Rule, 7> = ConstPrattParser::new_const([
-    ///     (Op::infix(Rule::add, Assoc::Left), 0), // lowest precedence
-    ///     (Op::infix(Rule::sub, Assoc::Left), 0), // same precedence as add
-    ///     (Op::infix(Rule::mul, Assoc::Left), 1), // next precedence level
-    ///     (Op::infix(Rule::div, Assoc::Left), 0), // same precedence as mul
-    ///     (Op::infix(Rule::pow, Assoc::Right), 1),
-    ///     (Op::prefix(Rule::neg), 1),
-    ///     (Op::postfix(Rule::fac), 1), // highest precedence
+    ///     (Op::infix(Rule::add, Assoc::Left), true), // lowest precedence
+    ///     (Op::infix(Rule::sub, Assoc::Left), false), // same precedence as add
+    ///     (Op::infix(Rule::mul, Assoc::Left), true), // next precedence level
+    ///     (Op::infix(Rule::div, Assoc::Left), false), // same precedence as mul
+    ///     (Op::infix(Rule::pow, Assoc::Right), true),
+    ///     (Op::prefix(Rule::neg), true),
+    ///     (Op::postfix(Rule::fac), true), // highest precedence
     /// ]);
     /// ```
-    pub const fn new_const(ops: [(Op<R>, u8); N]) -> Self {
-        let mut internal_ops = [(ops[0].0.rule, ops[0].0.affix, PREC_STEP); N];
-        let mut prec = PREC_STEP;
-        let mut index = 1;
+    pub const fn new_const(ops: [(Op<R>, bool); N]) -> Self {
+        const {
+            assert!(N > 0, "ConstPrattParser requires at least one operator");
+        }
+        assert!(
+            ops[0].1,
+            "the first operator must start a new precedence level (`true`)"
+        );
+
+        // The initial values are dummies; every entry is overwritten below.
+        let mut internal_ops: [(R, Affix, Prec); N] = [(ops[0].0.rule, Affix::Prefix, 0); N];
+        let mut prec = 0;
+        let mut index = 0;
         while index < N {
-            let (op, delta) = &ops[index];
-            prec += (*delta as Prec) * PREC_STEP;
+            let (op, new_level) = &ops[index];
+            assert!(
+                op.next.is_none(),
+                "chained operators (created with `|`) are not supported in ConstPrattParser"
+            );
+            if *new_level {
+                prec += PREC_STEP;
+            }
             internal_ops[index] = (op.rule, op.affix, prec);
             index += 1;
         }
@@ -523,6 +539,11 @@ where
 /// the same precedence, separated by `|`. Levels are separated by `,`; later
 /// levels bind more tightly than earlier ones.
 ///
+/// Each operator must be written as a two-segment call, for example
+/// `Op::infix(Rule::add, Assoc::Left)`. Fully qualified paths and turbofish
+/// forms are not accepted, because a macro matcher cannot follow an
+/// expression fragment with `|`. Import `Op` and use the short form.
+///
 /// # Example
 ///
 /// ```
@@ -537,20 +558,37 @@ where
 ///     Op::postfix(Rule::fac),
 /// ]);
 /// ```
+///
+/// Fully qualified paths are rejected with a compile error:
+///
+/// ```compile_fail
+/// # use pest::pratt_parser::{Assoc, ConstPrattParser, pratt_precedence};
+/// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// # enum Rule { expr, int, add, sub }
+/// static PRATT: ConstPrattParser<Rule, 2> = ConstPrattParser::new_const(pratt_precedence![
+///     pest::pratt_parser::Op::infix(Rule::add, Assoc::Left)
+///         | pest::pratt_parser::Op::infix(Rule::sub, Assoc::Left),
+/// ]);
+/// ```
 #[macro_export]
 macro_rules! pratt_precedence {
+    // Operators must use a two-segment path: `Op::infix(args)`.
     (
-        $first_head:ident :: $first_tail:ident $first_args:tt
-        $( | $head:ident :: $tail:ident $args:tt )*
-        $(, $next_head:ident :: $next_tail:ident $next_args:tt
-            $( | $next_rest_head:ident :: $next_rest_tail:ident $next_rest_args:tt )*
-        )* $(,)?
-    ) => {[
-        ( $first_head :: $first_tail $first_args, 0u8 )
-        $(, ( $head :: $tail $args, 0u8 ) )*
-        $(,
-            ( $next_head :: $next_tail $next_args, 1u8 )
-            $(, ( $next_rest_head :: $next_rest_tail $next_rest_args, 0u8 ) )*
-        )*
-    ]};
+        $(
+            $first_head:ident :: $first_tail:ident $first_args:tt
+            $( | $head:ident :: $tail:ident $args:tt )*
+        ),* $(,)?
+    ) => {
+        [$(
+            ( $first_head :: $first_tail $first_args, true )
+            $(, ( $head :: $tail $args, false ) )*
+        ),*]
+    };
+    ($($t:tt)*) => {
+        compile_error!(
+            "unsupported operator syntax in `pratt_precedence!`: \
+             each operator must be a two-segment call like `Op::infix(Rule::add, Assoc::Left)`; \
+             fully qualified paths and turbofish forms are not accepted"
+        )
+    };
 }

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -304,9 +304,9 @@ impl<R: RuleType + 'static, const N: usize> ConstPrattParser<R, N> {
     /// pairs.
     ///
     /// Just like [`PrattParser::op`], but for use in a `const` context. The `u8`
-    /// in each pair is a precedence delta: use `0` to keep the same precedence
-    /// as the previous operator, and `1` (or higher) to move to the next
-    /// precedence level. The first delta should be `0`.
+    /// in each pair is a precedence delta relative to the previous operator:
+    /// use `0` to keep the same precedence, and `1` (or higher) to move to the
+    /// next precedence level. The first delta must be `0`.
     ///
     /// # Example
     ///
@@ -359,12 +359,12 @@ impl<R: RuleType + 'static, const N: usize> ConstPrattParser<R, N> {
 
     #[inline]
     fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
-        let mut i = 0;
-        while i < N {
+        let mut i = N;
+        while i > 0 {
+            i -= 1;
             if self.ops[i].0 == *rule {
                 return Some((self.ops[i].1, self.ops[i].2));
             }
-            i += 1;
         }
         None
     }
@@ -540,14 +540,17 @@ where
 #[macro_export]
 macro_rules! pratt_precedence {
     (
-        $(
-            $first_head:ident :: $first_tail:ident $first_args:tt
-            $( | $head:ident :: $tail:ident $args:tt )*
-        ),* $(,)?
-    ) => {[$(
-        ( $first_head :: $first_tail $first_args, 1u8 ),
-        $(
-            ( $head :: $tail $args, 0u8 ),
+        $first_head:ident :: $first_tail:ident $first_args:tt
+        $( | $head:ident :: $tail:ident $args:tt )*
+        $(, $next_head:ident :: $next_tail:ident $next_args:tt
+            $( | $next_rest_head:ident :: $next_rest_tail:ident $next_rest_args:tt )*
+        )* $(,)?
+    ) => {[
+        ( $first_head :: $first_tail $first_args, 0u8 )
+        $(, ( $head :: $tail $args, 0u8 ) )*
+        $(,
+            ( $next_head :: $next_tail $next_args, 1u8 )
+            $(, ( $next_rest_head :: $next_rest_tail $next_rest_args, 0u8 ) )*
         )*
-    )*]};
+    ]};
 }

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -12,6 +12,7 @@
 
 use core::iter::Peekable;
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::BitOr;
 
 use alloc::boxed::Box;
@@ -19,6 +20,8 @@ use alloc::collections::BTreeMap;
 
 use crate::iterators::Pair;
 use crate::RuleType;
+
+pub use crate::pratt_precedence;
 
 /// Associativity of an infix binary operator, used by [`Op::infix(Assoc)`].
 ///
@@ -43,6 +46,9 @@ pub struct Op<R: RuleType> {
 }
 
 /// The position of an operator relative to its operand.
+///
+/// This is an implementation detail used by the Pratt parser internals.
+#[doc(hidden)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Affix {
     /// Prefix operator, appearing before its operand.
@@ -55,7 +61,7 @@ pub enum Affix {
 
 impl<R: RuleType> Op<R> {
     /// Defines `rule` as a prefix unary operator.
-    pub fn prefix(rule: R) -> Self {
+    pub const fn prefix(rule: R) -> Self {
         Self {
             rule,
             affix: Affix::Prefix,
@@ -64,7 +70,7 @@ impl<R: RuleType> Op<R> {
     }
 
     /// Defines `rule` as a postfix unary operator.
-    pub fn postfix(rule: R) -> Self {
+    pub const fn postfix(rule: R) -> Self {
         Self {
             rule,
             affix: Affix::Postfix,
@@ -73,7 +79,7 @@ impl<R: RuleType> Op<R> {
     }
 
     /// Defines `rule` as an infix binary operator with associativity `assoc`.
-    pub fn infix(rule: R, assoc: Assoc) -> Self {
+    pub const fn infix(rule: R, assoc: Assoc) -> Self {
         Self {
             rule,
             affix: Affix::Infix(assoc),
@@ -117,7 +123,7 @@ impl<R: RuleType> BitOr for Op<R> {
 ///
 /// ```pest
 /// WHITESPACE   =  _{ " " | "\t" | NEWLINE }
-///  
+///
 /// program      =   { SOI ~ expr ~ EOI }
 ///   expr       =   { prefix* ~ primary ~ postfix* ~ (infix ~ prefix* ~ primary ~ postfix* )* }
 ///     infix    =  _{ add | sub | mul | div | pow }
@@ -258,11 +264,19 @@ impl<R: RuleType> PrattParser<R> {
             phantom: PhantomData,
         }
     }
+
+    fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
+        self.ops.get(rule).copied()
+    }
 }
 
-/// Trait for types that provide operator metadata to [`PrattParserMap`].
+/// Internal trait for types that provide operator metadata to [`PrattParserMap`].
+///
+/// This trait is an implementation detail and not intended to be implemented
+/// by downstream code.
 ///
 /// [`PrattParserMap`]: struct.PrattParserMap.html
+#[doc(hidden)]
 pub trait PrattParserOps<R: RuleType> {
     /// Look up the affix and precedence of `rule`.
     fn get(&self, rule: &R) -> Option<(Affix, Prec)>;
@@ -270,7 +284,7 @@ pub trait PrattParserOps<R: RuleType> {
 
 impl<R: RuleType> PrattParserOps<R> for PrattParser<R> {
     fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
-        self.ops.get(rule).copied()
+        PrattParser::get(self, rule)
     }
 }
 
@@ -278,37 +292,50 @@ impl<R: RuleType> PrattParserOps<R> for PrattParser<R> {
 /// memory.
 ///
 /// It is functionally equivalent to [`PrattParser`], but it is constructed from
-/// a static slice of operators rather than the chained `.op(...)` builder.
+/// a static array of [`Op`]s rather than the chained `.op(...)` builder.
 ///
 /// [`PrattParser`]: struct.PrattParser.html
-pub struct ConstPrattParser<R: RuleType + 'static> {
-    ops: &'static [(R, Affix, Prec)],
+pub struct ConstPrattParser<R: RuleType + 'static, const N: usize> {
+    ops: [(R, Affix, Prec); N],
 }
 
-impl<R: RuleType + 'static> ConstPrattParser<R> {
-    /// Create a `ConstPrattParser` from a static slice of operators.
+impl<R: RuleType + 'static, const N: usize> ConstPrattParser<R, N> {
+    /// Create a `ConstPrattParser` from a static array of (`[`Op`]`, `u8`)
+    /// pairs.
     ///
-    /// Each tuple is `(rule, affix, precedence)`. Higher precedence values bind
-    /// more tightly. The absolute values do not matter, only their ordering.
+    /// Just like [`PrattParser::op`], but for use in a `const` context. The `u8`
+    /// in each pair is a precedence delta: use `0` to keep the same precedence
+    /// as the previous operator, and `1` (or higher) to move to the next
+    /// precedence level. The first delta should be `0`.
     ///
     /// # Example
     ///
     /// ```
-    /// # use pest::pratt_parser::{Affix, Assoc, ConstPrattParser};
+    /// # use pest::pratt_parser::{Assoc, ConstPrattParser, Op};
     /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     /// # enum Rule { expr, int, add, sub, mul, div, pow, neg, fac }
-    /// static PRATT: ConstPrattParser<Rule> = ConstPrattParser::new_const(&[
-    ///     (Rule::add, Affix::Infix(Assoc::Left), 1),
-    ///     (Rule::sub, Affix::Infix(Assoc::Left), 1),
-    ///     (Rule::mul, Affix::Infix(Assoc::Left), 2),
-    ///     (Rule::div, Affix::Infix(Assoc::Left), 2),
-    ///     (Rule::pow, Affix::Infix(Assoc::Right), 3),
-    ///     (Rule::neg, Affix::Prefix, 4),
-    ///     (Rule::fac, Affix::Postfix, 5),
+    /// static PRATT: ConstPrattParser<Rule, 7> = ConstPrattParser::new_const([
+    ///     (Op::infix(Rule::add, Assoc::Left), 0), // lowest precedence
+    ///     (Op::infix(Rule::sub, Assoc::Left), 0), // same precedence as add
+    ///     (Op::infix(Rule::mul, Assoc::Left), 1), // next precedence level
+    ///     (Op::infix(Rule::div, Assoc::Left), 0), // same precedence as mul
+    ///     (Op::infix(Rule::pow, Assoc::Right), 1),
+    ///     (Op::prefix(Rule::neg), 1),
+    ///     (Op::postfix(Rule::fac), 1), // highest precedence
     /// ]);
     /// ```
-    pub const fn new_const(ops: &'static [(R, Affix, Prec)]) -> Self {
-        Self { ops }
+    pub const fn new_const(ops: [(Op<R>, u8); N]) -> Self {
+        let mut internal_ops = [(ops[0].0.rule, ops[0].0.affix, PREC_STEP); N];
+        let mut prec = PREC_STEP;
+        let mut index = 1;
+        while index < N {
+            let (op, delta) = &ops[index];
+            prec += (*delta as Prec) * PREC_STEP;
+            internal_ops[index] = (op.rule, op.affix, prec);
+            index += 1;
+        }
+        let _ = ManuallyDrop::new(ops);
+        Self { ops: internal_ops }
     }
 
     /// Maps primary expressions with a closure `primary`.
@@ -329,18 +356,23 @@ impl<R: RuleType + 'static> ConstPrattParser<R> {
             phantom: PhantomData,
         }
     }
-}
 
-impl<R: RuleType + 'static> PrattParserOps<R> for ConstPrattParser<R> {
+    #[inline]
     fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
         let mut i = 0;
-        while i < self.ops.len() {
+        while i < N {
             if self.ops[i].0 == *rule {
                 return Some((self.ops[i].1, self.ops[i].2));
             }
             i += 1;
         }
         None
+    }
+}
+
+impl<R: RuleType + 'static, const N: usize> PrattParserOps<R> for ConstPrattParser<R, N> {
+    fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
+        ConstPrattParser::get(self, rule)
     }
 }
 
@@ -483,4 +515,39 @@ where
             None => 0,
         }
     }
+}
+
+/// Convenience macro for building a const Pratt parser precedence table.
+///
+/// Each argument is a precedence level: a list of [`Op`] constructors sharing
+/// the same precedence, separated by `|`. Levels are separated by `,`; later
+/// levels bind more tightly than earlier ones.
+///
+/// # Example
+///
+/// ```
+/// # use pest::pratt_parser::{Assoc, ConstPrattParser, Op, pratt_precedence};
+/// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// # enum Rule { expr, int, add, sub, mul, div, pow, neg, fac }
+/// static PRATT: ConstPrattParser<Rule, 7> = ConstPrattParser::new_const(pratt_precedence![
+///     Op::infix(Rule::add, Assoc::Left) | Op::infix(Rule::sub, Assoc::Left),
+///     Op::infix(Rule::mul, Assoc::Left) | Op::infix(Rule::div, Assoc::Left),
+///     Op::infix(Rule::pow, Assoc::Right),
+///     Op::prefix(Rule::neg),
+///     Op::postfix(Rule::fac),
+/// ]);
+/// ```
+#[macro_export]
+macro_rules! pratt_precedence {
+    (
+        $(
+            $first_head:ident :: $first_tail:ident $first_args:tt
+            $( | $head:ident :: $tail:ident $args:tt )*
+        ),* $(,)?
+    ) => {[$(
+        ( $first_head :: $first_tail $first_args, 1u8 ),
+        $(
+            ( $head :: $tail $args, 0u8 ),
+        )*
+    )*]};
 }

--- a/pest/src/pratt_parser.rs
+++ b/pest/src/pratt_parser.rs
@@ -31,7 +31,8 @@ pub enum Assoc {
     Right,
 }
 
-type Prec = u32;
+/// Operator precedence level.
+pub type Prec = u32;
 const PREC_STEP: Prec = 10;
 
 /// An operator that corresponds to a rule.
@@ -41,9 +42,14 @@ pub struct Op<R: RuleType> {
     next: Option<Box<Op<R>>>,
 }
 
-enum Affix {
+/// The position of an operator relative to its operand.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Affix {
+    /// Prefix operator, appearing before its operand.
     Prefix,
+    /// Postfix operator, appearing after its operand.
     Postfix,
+    /// Infix binary operator with the given associativity.
     Infix(Assoc),
 }
 
@@ -254,21 +260,107 @@ impl<R: RuleType> PrattParser<R> {
     }
 }
 
+/// Trait for types that provide operator metadata to [`PrattParserMap`].
+///
+/// [`PrattParserMap`]: struct.PrattParserMap.html
+pub trait PrattParserOps<R: RuleType> {
+    /// Look up the affix and precedence of `rule`.
+    fn get(&self, rule: &R) -> Option<(Affix, Prec)>;
+}
+
+impl<R: RuleType> PrattParserOps<R> for PrattParser<R> {
+    fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
+        self.ops.get(rule).copied()
+    }
+}
+
+/// A Pratt parser that can be built in a `const` context and stored in static
+/// memory.
+///
+/// It is functionally equivalent to [`PrattParser`], but it is constructed from
+/// a static slice of operators rather than the chained `.op(...)` builder.
+///
+/// [`PrattParser`]: struct.PrattParser.html
+pub struct ConstPrattParser<R: RuleType + 'static> {
+    ops: &'static [(R, Affix, Prec)],
+}
+
+impl<R: RuleType + 'static> ConstPrattParser<R> {
+    /// Create a `ConstPrattParser` from a static slice of operators.
+    ///
+    /// Each tuple is `(rule, affix, precedence)`. Higher precedence values bind
+    /// more tightly. The absolute values do not matter, only their ordering.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use pest::pratt_parser::{Affix, Assoc, ConstPrattParser};
+    /// # #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    /// # enum Rule { expr, int, add, sub, mul, div, pow, neg, fac }
+    /// static PRATT: ConstPrattParser<Rule> = ConstPrattParser::new_const(&[
+    ///     (Rule::add, Affix::Infix(Assoc::Left), 1),
+    ///     (Rule::sub, Affix::Infix(Assoc::Left), 1),
+    ///     (Rule::mul, Affix::Infix(Assoc::Left), 2),
+    ///     (Rule::div, Affix::Infix(Assoc::Left), 2),
+    ///     (Rule::pow, Affix::Infix(Assoc::Right), 3),
+    ///     (Rule::neg, Affix::Prefix, 4),
+    ///     (Rule::fac, Affix::Postfix, 5),
+    /// ]);
+    /// ```
+    pub const fn new_const(ops: &'static [(R, Affix, Prec)]) -> Self {
+        Self { ops }
+    }
+
+    /// Maps primary expressions with a closure `primary`.
+    pub fn map_primary<'pratt, 'a, 'i, X, T>(
+        &'pratt self,
+        primary: X,
+    ) -> PrattParserMap<'pratt, 'a, 'i, R, X, T, Self>
+    where
+        X: FnMut(Pair<'i, R>) -> T,
+        R: 'pratt,
+    {
+        PrattParserMap {
+            pratt: self,
+            primary,
+            prefix: None,
+            postfix: None,
+            infix: None,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<R: RuleType + 'static> PrattParserOps<R> for ConstPrattParser<R> {
+    fn get(&self, rule: &R) -> Option<(Affix, Prec)> {
+        let mut i = 0;
+        while i < self.ops.len() {
+            if self.ops[i].0 == *rule {
+                return Some((self.ops[i].1, self.ops[i].2));
+            }
+            i += 1;
+        }
+        None
+    }
+}
+
 type PrefixFn<'a, 'i, R, T> = Box<dyn FnMut(Pair<'i, R>, T) -> T + 'a>;
 type PostfixFn<'a, 'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>) -> T + 'a>;
 type InfixFn<'a, 'i, R, T> = Box<dyn FnMut(T, Pair<'i, R>, T) -> T + 'a>;
 
-/// Product of calling [`map_primary`] on [`PrattParser`], defines how expressions should
-/// be mapped.
+/// Product of calling [`map_primary`] on a [`PrattParser`] or [`ConstPrattParser`],
+/// defines how expressions should be mapped.
 ///
 /// [`map_primary`]: struct.PrattParser.html#method.map_primary
 /// [`PrattParser`]: struct.PrattParser.html
-pub struct PrattParserMap<'pratt, 'a, 'i, R, F, T>
+/// [`ConstPrattParser`]: struct.ConstPrattParser.html
+pub struct PrattParserMap<'pratt, 'a, 'i, R, F, T, P = PrattParser<R>>
 where
     R: RuleType,
     F: FnMut(Pair<'i, R>) -> T,
+    P: PrattParserOps<R>,
 {
-    pratt: &'pratt PrattParser<R>,
+    pratt: &'pratt P,
     primary: F,
     prefix: Option<PrefixFn<'a, 'i, R, T>>,
     postfix: Option<PostfixFn<'a, 'i, R, T>>,
@@ -276,10 +368,11 @@ where
     phantom: PhantomData<T>,
 }
 
-impl<'pratt, 'a, 'i, R, F, T> PrattParserMap<'pratt, 'a, 'i, R, F, T>
+impl<'pratt, 'a, 'i, R, F, T, P> PrattParserMap<'pratt, 'a, 'i, R, F, T, P>
 where
     R: RuleType + 'pratt,
     F: FnMut(Pair<'i, R>) -> T,
+    P: PrattParserOps<R> + 'pratt,
 {
     /// Maps prefix operators with closure `prefix`.
     pub fn map_prefix<X>(mut self, prefix: X) -> Self
@@ -322,11 +415,11 @@ where
     /// [`map_prefix`]: struct.PrattParserMap.html#method.map_prefix
     /// [`map_postfix`]: struct.PrattParserMap.html#method.map_postfix
     /// [`map_infix`]: struct.PrattParserMap.html#method.map_infix
-    pub fn parse<P: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: P) -> T {
+    pub fn parse<I: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: I) -> T {
         self.expr(&mut pairs.peekable(), 0)
     }
 
-    fn expr<P: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<P>, rbp: Prec) -> T {
+    fn expr<I: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<I>, rbp: Prec) -> T {
         let mut lhs = self.nud(pairs);
         while rbp < self.lbp(pairs) {
             lhs = self.led(pairs, lhs);
@@ -338,11 +431,11 @@ where
     ///
     /// "the action that should happen when the symbol is encountered
     ///  as start of an expression (most notably, prefix operators)
-    fn nud<P: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<P>) -> T {
+    fn nud<I: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<I>) -> T {
         let pair = pairs.next().expect("Pratt parsing expects non-empty Pairs");
-        match self.pratt.ops.get(&pair.as_rule()) {
+        match self.pratt.get(&pair.as_rule()) {
             Some((Affix::Prefix, prec)) => {
-                let rhs = self.expr(pairs, *prec - 1);
+                let rhs = self.expr(pairs, prec - 1);
                 match self.prefix.as_mut() {
                     Some(prefix) => prefix(pair, rhs),
                     None => panic!("Could not map {}, no `.map_prefix(...)` specified", pair),
@@ -357,13 +450,13 @@ where
     ///
     /// "the action that should happen when the symbol is encountered
     /// after the start of an expression (most notably, infix and postfix operators)"
-    fn led<P: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<P>, lhs: T) -> T {
+    fn led<I: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<I>, lhs: T) -> T {
         let pair = pairs.next().unwrap();
-        match self.pratt.ops.get(&pair.as_rule()) {
+        match self.pratt.get(&pair.as_rule()) {
             Some((Affix::Infix(assoc), prec)) => {
-                let rhs = match *assoc {
-                    Assoc::Left => self.expr(pairs, *prec),
-                    Assoc::Right => self.expr(pairs, *prec - 1),
+                let rhs = match assoc {
+                    Assoc::Left => self.expr(pairs, prec),
+                    Assoc::Right => self.expr(pairs, prec - 1),
                 };
                 match self.infix.as_mut() {
                     Some(infix) => infix(lhs, pair, rhs),
@@ -381,10 +474,10 @@ where
     /// Left-Binding-Power
     ///
     /// "describes the symbol's precedence in infix form (most notably, operator precedence)"
-    fn lbp<P: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<P>) -> Prec {
+    fn lbp<I: Iterator<Item = Pair<'i, R>>>(&mut self, pairs: &mut Peekable<I>) -> Prec {
         match pairs.peek() {
-            Some(pair) => match self.pratt.ops.get(&pair.as_rule()) {
-                Some((_, prec)) => *prec,
+            Some(pair) => match self.pratt.get(&pair.as_rule()) {
+                Some((_, prec)) => prec,
                 None => panic!("Expected operator, found {}", pair),
             },
             None => 0,

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -274,14 +274,13 @@ fn const_pratt_parse() {
 fn const_pratt_macro_parse() {
     use pest::pratt_parser::pratt_precedence;
 
-    static PRATT: ConstPrattParser<Rule, 6> =
-        ConstPrattParser::new_const(pratt_precedence![
-            Op::infix(Rule::plus, Assoc::Left) | Op::infix(Rule::minus, Assoc::Left),
-            Op::infix(Rule::times, Assoc::Left)
-                | Op::infix(Rule::divide, Assoc::Left)
-                | Op::infix(Rule::modulus, Assoc::Left),
-            Op::infix(Rule::power, Assoc::Right),
-        ]);
+    static PRATT: ConstPrattParser<Rule, 6> = ConstPrattParser::new_const(pratt_precedence![
+        Op::infix(Rule::plus, Assoc::Left) | Op::infix(Rule::minus, Assoc::Left),
+        Op::infix(Rule::times, Assoc::Left)
+            | Op::infix(Rule::divide, Assoc::Left)
+            | Op::infix(Rule::modulus, Assoc::Left),
+        Op::infix(Rule::power, Assoc::Right),
+    ]);
 
     let pairs = CalculatorParser::parse(Rule::expression, "-12+3*(4-9)^3^2/9%7381");
     assert_eq!(

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -12,7 +12,7 @@ extern crate pest;
 
 use pest::error::Error;
 use pest::iterators::{Pair, Pairs};
-use pest::pratt_parser::{Assoc, Op, PrattParser};
+use pest::pratt_parser::{Affix, Assoc, ConstPrattParser, Op, PrattParser};
 use pest::{state, ParseResult, Parser, ParserState};
 
 #[allow(dead_code, non_camel_case_types)]
@@ -116,6 +116,7 @@ impl Parser<Rule> for CalculatorParser {
 #[allow(deprecated)]
 enum PrattOrPrecClimber<'a> {
     Pratt(&'a PrattParser<Rule>),
+    ConstPratt(&'a ConstPrattParser<Rule>),
     PrecClimber(&'a pest::prec_climber::PrecClimber<Rule>),
 }
 
@@ -134,6 +135,10 @@ fn consume(pair: Pair<Rule>, pratt_or_climber: &PrattOrPrecClimber) -> i32 {
     #[allow(deprecated)]
     match (pair.as_rule(), pratt_or_climber) {
         (Rule::expression, PrattOrPrecClimber::Pratt(pratt)) => pratt
+            .map_primary(primary)
+            .map_infix(infix)
+            .parse(pair.into_inner()),
+        (Rule::expression, PrattOrPrecClimber::ConstPratt(pratt)) => pratt
             .map_primary(primary)
             .map_infix(infix)
             .parse(pair.into_inner()),
@@ -240,6 +245,27 @@ fn pratt_parse() {
         consume(
             pairs.unwrap().next().unwrap(),
             &PrattOrPrecClimber::Pratt(&pratt)
+        )
+    );
+}
+
+#[test]
+fn const_pratt_parse() {
+    static PRATT: ConstPrattParser<Rule> = ConstPrattParser::new_const(&[
+        (Rule::plus, Affix::Infix(Assoc::Left), 1),
+        (Rule::minus, Affix::Infix(Assoc::Left), 1),
+        (Rule::times, Affix::Infix(Assoc::Left), 2),
+        (Rule::divide, Affix::Infix(Assoc::Left), 2),
+        (Rule::modulus, Affix::Infix(Assoc::Left), 2),
+        (Rule::power, Affix::Infix(Assoc::Right), 3),
+    ]);
+
+    let pairs = CalculatorParser::parse(Rule::expression, "-12+3*(4-9)^3^2/9%7381");
+    assert_eq!(
+        -1_525,
+        consume(
+            pairs.unwrap().next().unwrap(),
+            &PrattOrPrecClimber::ConstPratt(&PRATT)
         )
     );
 }

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -12,7 +12,7 @@ extern crate pest;
 
 use pest::error::Error;
 use pest::iterators::{Pair, Pairs};
-use pest::pratt_parser::{Affix, Assoc, ConstPrattParser, Op, PrattParser};
+use pest::pratt_parser::{Assoc, ConstPrattParser, Op, PrattParser};
 use pest::{state, ParseResult, Parser, ParserState};
 
 #[allow(dead_code, non_camel_case_types)]
@@ -116,7 +116,7 @@ impl Parser<Rule> for CalculatorParser {
 #[allow(deprecated)]
 enum PrattOrPrecClimber<'a> {
     Pratt(&'a PrattParser<Rule>),
-    ConstPratt(&'a ConstPrattParser<Rule>),
+    ConstPratt(&'a ConstPrattParser<Rule, 6>),
     PrecClimber(&'a pest::prec_climber::PrecClimber<Rule>),
 }
 
@@ -251,14 +251,37 @@ fn pratt_parse() {
 
 #[test]
 fn const_pratt_parse() {
-    static PRATT: ConstPrattParser<Rule> = ConstPrattParser::new_const(&[
-        (Rule::plus, Affix::Infix(Assoc::Left), 1),
-        (Rule::minus, Affix::Infix(Assoc::Left), 1),
-        (Rule::times, Affix::Infix(Assoc::Left), 2),
-        (Rule::divide, Affix::Infix(Assoc::Left), 2),
-        (Rule::modulus, Affix::Infix(Assoc::Left), 2),
-        (Rule::power, Affix::Infix(Assoc::Right), 3),
+    static PRATT: ConstPrattParser<Rule, 6> = ConstPrattParser::new_const([
+        (Op::infix(Rule::plus, Assoc::Left), 0),
+        (Op::infix(Rule::minus, Assoc::Left), 0),
+        (Op::infix(Rule::times, Assoc::Left), 1),
+        (Op::infix(Rule::divide, Assoc::Left), 0),
+        (Op::infix(Rule::modulus, Assoc::Left), 0),
+        (Op::infix(Rule::power, Assoc::Right), 1),
     ]);
+
+    let pairs = CalculatorParser::parse(Rule::expression, "-12+3*(4-9)^3^2/9%7381");
+    assert_eq!(
+        -1_525,
+        consume(
+            pairs.unwrap().next().unwrap(),
+            &PrattOrPrecClimber::ConstPratt(&PRATT)
+        )
+    );
+}
+
+#[test]
+fn const_pratt_macro_parse() {
+    use pest::pratt_parser::pratt_precedence;
+
+    static PRATT: ConstPrattParser<Rule, 6> =
+        ConstPrattParser::new_const(pratt_precedence![
+            Op::infix(Rule::plus, Assoc::Left) | Op::infix(Rule::minus, Assoc::Left),
+            Op::infix(Rule::times, Assoc::Left)
+                | Op::infix(Rule::divide, Assoc::Left)
+                | Op::infix(Rule::modulus, Assoc::Left),
+            Op::infix(Rule::power, Assoc::Right),
+        ]);
 
     let pairs = CalculatorParser::parse(Rule::expression, "-12+3*(4-9)^3^2/9%7381");
     assert_eq!(

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -252,12 +252,12 @@ fn pratt_parse() {
 #[test]
 fn const_pratt_parse() {
     static PRATT: ConstPrattParser<Rule, 6> = ConstPrattParser::new_const([
-        (Op::infix(Rule::plus, Assoc::Left), 0),
-        (Op::infix(Rule::minus, Assoc::Left), 0),
-        (Op::infix(Rule::times, Assoc::Left), 1),
-        (Op::infix(Rule::divide, Assoc::Left), 0),
-        (Op::infix(Rule::modulus, Assoc::Left), 0),
-        (Op::infix(Rule::power, Assoc::Right), 1),
+        (Op::infix(Rule::plus, Assoc::Left), true),
+        (Op::infix(Rule::minus, Assoc::Left), false),
+        (Op::infix(Rule::times, Assoc::Left), true),
+        (Op::infix(Rule::divide, Assoc::Left), false),
+        (Op::infix(Rule::modulus, Assoc::Left), false),
+        (Op::infix(Rule::power, Assoc::Right), true),
     ]);
 
     let pairs = CalculatorParser::parse(Rule::expression, "-12+3*(4-9)^3^2/9%7381");


### PR DESCRIPTION
## Summary

Adds `ConstPrattParser<R, N>`, a fully-functional Pratt parser that can be built entirely in a `const` context and stored in static memory. This is especially useful in `no_std` environments where resources are generally limited and the availability of threads and synchronization primitives is greatly reduced, since it removes the need for `lazy_static`/`LazyLock` or similar runtime initialization.

Key changes:
- `ConstPrattParser::new_const(ops: [(Op<R>, u8); N])` builds the operator table at compile time. The `u8` is a precedence delta relative to the previous operator; the first delta is `0`.
- Adds the optional `pratt_precedence!` declarative macro for convenient grouping:
  ```rust
  static PRATT: ConstPrattParser<Rule, 7> = ConstPrattParser::new_const(pratt_precedence![
      Op::infix(Rule::add, Assoc::Left) | Op::infix(Rule::sub, Assoc::Left),
      Op::infix(Rule::mul, Assoc::Left) | Op::infix(Rule::div, Assoc::Left),
      Op::infix(Rule::pow, Assoc::Right),
      Op::prefix(Rule::neg),
      Op::postfix(Rule::fac),
  ]);
  ```
- Duplicate rules are resolved by the last configuration: `ConstPrattParser::get` scans the array in reverse, matching `PrattParser::op` behavior.
- Shares parse logic between `PrattParser` and `ConstPrattParser` via a `PrattParserOps` trait.
- Updates calculator tests (raw-array case + macro case) and adds a Pratt benchmark.

## Related work

The `experimental-simd-pratt` branch explored SIMD-accelerated const lookup for 2-byte rule enums on aarch64 NEON. It showed promising numbers (~40–44 ns vs ~83 ns for the runtime BTreeMap on Apple Silicon), but it is intentionally incomplete and was **not** included here. It would need u8/u16 lanes for aarch64 and x86_64, plus runtime feature detection, before it could be considered general.

## Test plan

- [x] `cargo test` passes in `pest/pest`
- [x] `just verify` passes in the Melbi const-pratt worktree using the new API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for constructing Pratt parsers at compile time.
  * Added a precedence macro for defining operator configurations.
  * Exposed operator precedence and associativity types for advanced parser configuration.
  * Added benchmark coverage comparing runtime and compile-time operator lookups.

* **Tests**
  * Added calculator tests verifying compile-time parser construction and precedence configuration preserve existing arithmetic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->