### PR TITLE
fix: silence compiler and clippy warnings in tests and generator

### DIFF
--- a/derive/tests/implicit.rs
+++ b/derive/tests/implicit.rs
@@ -11,8 +11,10 @@ extern crate pest_derive;
 
 #[cfg(feature = "grammar-extras")]
 use pest::Parser;
+#[cfg(feature = "grammar-extras")]
 use pest_derive::Parser;
 
+#[cfg(feature = "grammar-extras")]
 #[derive(Parser)]
 #[grammar = "../tests/implicit.pest"]
 struct TestImplicitParser;

--- a/derive/tests/opt.rs
+++ b/derive/tests/opt.rs
@@ -11,8 +11,10 @@ extern crate pest_derive;
 
 #[cfg(feature = "grammar-extras")]
 use pest::Parser;
+#[cfg(feature = "grammar-extras")]
 use pest_derive::Parser;
 
+#[cfg(feature = "grammar-extras")]
 #[derive(Parser)]
 #[grammar = "../tests/opt.pest"]
 struct TestOptParser;

--- a/derive/tests/surround.rs
+++ b/derive/tests/surround.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
-#[macro_use]
+#[cfg_attr(feature = "grammar-extras", macro_use)]
 extern crate pest;
 extern crate pest_derive;
 

--- a/generator/src/docs.rs
+++ b/generator/src/docs.rs
@@ -61,15 +61,13 @@ pub fn consume(pairs: Pairs<'_, Rule>) -> DocComment {
                                 line_doc.push('\n');
                             }
                         }
-                        Rule::identifier => {
-                            if !line_doc.is_empty() {
-                                let rule_name = inner.as_str().to_owned();
+                        Rule::identifier if !line_doc.is_empty() => {
+                            let rule_name = inner.as_str().to_owned();
 
-                                // Remove last \n
-                                line_doc.pop();
-                                line_docs.insert(rule_name, line_doc.clone());
-                                line_doc.clear();
-                            }
+                            // Remove last \n
+                            line_doc.pop();
+                            line_docs.insert(rule_name, line_doc.clone());
+                            line_doc.clear();
                         }
                         _ => (),
                     }

--- a/pest/examples/parens.rs
+++ b/pest/examples/parens.rs
@@ -17,7 +17,7 @@ enum Rule {
 struct ParenParser;
 
 impl Parser<Rule> for ParenParser {
-    fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+    fn parse(rule: Rule, input: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
         fn expr(state: Box<ParserState<'_, Rule>>) -> ParseResult<Box<ParserState<'_, Rule>>> {
             state.sequence(|s| s.repeat(paren).and_then(|s| s.end_of_input()))
         }

--- a/pest/tests/calculator.rs
+++ b/pest/tests/calculator.rs
@@ -34,7 +34,7 @@ struct CalculatorParser;
 impl Parser<Rule> for CalculatorParser {
     // false positive: pest uses `..` as a complete range (historically)
     #[allow(clippy::almost_complete_range)]
-    fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+    fn parse(rule: Rule, input: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
         fn expression(
             state: Box<ParserState<'_, Rule>>,
         ) -> ParseResult<Box<ParserState<'_, Rule>>> {

--- a/pest/tests/json.rs
+++ b/pest/tests/json.rs
@@ -40,7 +40,7 @@ struct JsonParser;
 impl Parser<Rule> for JsonParser {
     // false positive: pest uses `..` as a complete range (historically)
     #[allow(clippy::almost_complete_range)]
-    fn parse(rule: Rule, input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+    fn parse(rule: Rule, input: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
         fn json(state: Box<ParserState<'_, Rule>>) -> ParseResult<Box<ParserState<'_, Rule>>> {
             value(state)
         }


### PR DESCRIPTION
Also, these warnings were getting in the way all the time. So I ended up fixing them too.

- Add explicit `'_` lifetime in `Parser::parse` impls to match the trait
- Gate opt/implicit test parsers and imports behind `grammar-extras` (they are only used by feature-gated tests)
- Gate `#[macro_use]` in surround test behind `grammar-extras`
- Collapse a nested `if` into a match guard in generator's docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature-gated parser test configurations so grammar-related code is excluded when optional grammar features are disabled.
  * Improved documentation processing for identifiers without documentation text.
  * Updated parser examples and tests to align with current lifetime requirements without changing parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->