### PR TITLE
fix(debugger): upgrade rustyline to 13 for loongarch64 support

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "= 0.11.13", default-features = false, features = [
     "json",
     "default-tls",
 ] }
-rustyline = "13"
+rustyline = { version = "13", default-features = false, features = ["custom-bindings", "with-file-history"] }
 serde_json = "1"
 thiserror = "2"
 

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "= 0.11.13", default-features = false, features = [
     "json",
     "default-tls",
 ] }
-rustyline = "10"
+rustyline = "13"
 serde_json = "1"
 thiserror = "2"
 

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -27,6 +27,7 @@ use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::history::DefaultHistory;
 use rustyline::validate::Validator;
 use rustyline::{Editor, Helper};
 
@@ -342,7 +343,7 @@ impl CliArgs {
 }
 
 fn main() -> rustyline::Result<()> {
-    let mut rl = Editor::<CliHelper>::new()?;
+    let mut rl = Editor::<CliHelper, DefaultHistory>::new()?;
     let mut context = Cli::default();
     let cli_args = CliArgs::default();
 
@@ -387,7 +388,9 @@ fn main() -> rustyline::Result<()> {
     loop {
         match rl.readline("> ") {
             Ok(line) => {
-                rl.add_history_entry(line.clone());
+                if let Err(err) = rl.add_history_entry(line.clone()) {
+                    eprintln!("Error adding history entry: {}", err);
+                }
                 if let Err(err) = context.execute_command(line.trim()) {
                     println!("Error: {}", err);
                 }


### PR DESCRIPTION
pest_debugger fails to compile on loongarch64-unknown-linux-gnu because rustyline 10 pulls in nix 0.25, whose ioctl module does not support the loongarch64 architecture. Bump to rustyline 13, which uses nix 0.27 and adds loongarch64 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugger command-history handling for more reliable interactive sessions.
  * Added clearer feedback when a command cannot be saved to history.
  * Updated debugger terminal input support for compatibility with the latest functionality.
  * Improved persistence and loading of command history between debugger sessions.
  * Enhanced stability when entering and recalling commands from the debugger history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->