### PR TITLE
fix(grammars/fuzz): add missing edition = "2021"

### DIFF
--- a/grammars/fuzz/Cargo.toml
+++ b/grammars/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 rust-version = "1.83"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/grammars/fuzz/fuzz_targets/sql.rs
+++ b/grammars/fuzz/fuzz_targets/sql.rs
@@ -1,0 +1,14 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate pest;
+extern crate pest_grammars;
+
+fuzz_target!(|data: &[u8]| {
+    use pest_grammars::sql;
+    use pest_grammars::Parser;
+
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = sql::SqlParser::parse(sql::Rule::SQL, s);
+    }
+});


### PR DESCRIPTION
Adding "`edition = "2021"`" to the pest/grammars/fuzz/Cargo.toml file. This addition suppress the following warning:

```
warning: Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2021 is compatible with `rust-version`
warning: `pest_grammars-fuzz` (manifest) generated 1 warning
```

Given the set rust version is "`rust-version = "1.83"`", which was released in 2024, setting "`edition = "2021"`" should be fine as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the fuzzing package to use the Rust 2021 edition.

* **Tests**
  * Added automated fuzz testing for SQL grammar parsing to help identify handling issues with varied input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->