### PR TITLE
fix(fuzz): set edition 2021 and add sql fuzz target

### DIFF
--- a/grammars/fuzz/Cargo.toml
+++ b/grammars/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 rust-version = "1.83"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/grammars/fuzz/Cargo.toml
+++ b/grammars/fuzz/Cargo.toml
@@ -31,3 +31,7 @@ path = "fuzz_targets/json.rs"
 [[bin]]
 name = "toml"
 path = "fuzz_targets/toml.rs"
+
+[[bin]]
+name = "sql"
+path = "fuzz_targets/sql.rs"

--- a/grammars/fuzz/fuzz_targets/sql.rs
+++ b/grammars/fuzz/fuzz_targets/sql.rs
@@ -1,0 +1,14 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate pest;
+extern crate pest_grammars;
+
+fuzz_target!(|data: &[u8]| {
+    use pest_grammars::sql;
+    use pest_grammars::Parser;
+
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = sql::SqlParser::parse(sql::Rule::SQL, s);
+    }
+});

--- a/meta/fuzz/Cargo.toml
+++ b/meta/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 rust-version = "1.83"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
Adding "`edition = "2021"`" to both `grammars/fuzz/Cargo.toml` and `meta/fuzz/Cargo.toml'. These additions suppress the warning: 

```
warning: Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2021 is compatible with `rust-version`
warning: `pest_grammars-fuzz` (manifest) generated 1 warning
```

Also, the sql.pest grammar was lacking a fuzz target. Adding the target for said grammar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated fuzz testing for SQL grammar parsing, including valid UTF-8 input handling and safe treatment of invalid input.
  * Improved coverage for detecting unexpected parsing issues across a broader range of SQL inputs.
* **Chores**
  * Updated fuzz-testing packages to use the Rust 2021 edition, improving compatibility with the current Rust ecosystem and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->