### PR TITLE
Reject unescaped control characters in the JSON grammar

### DIFF
--- a/grammars/src/grammars/json.pest
+++ b/grammars/src/grammars/json.pest
@@ -26,7 +26,7 @@ array = { "[" ~ value ~ ("," ~ value)* ~ "]" | "[" ~ "]" }
 value = { string | number | object | array | bool | null }
 
 string  = @{ "\"" ~ inner ~ "\"" }
-inner   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ inner)? }
+inner   = @{ (!("\"" | "\\" | '\u{0000}'..'\u{001F}') ~ ANY)* ~ (escape ~ inner)? }
 escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
 

--- a/grammars/src/lib.rs
+++ b/grammars/src/lib.rs
@@ -116,9 +116,14 @@ mod tests {
         let s1 = json::JsonParser::parse(json::Rule::json, sample1);
         assert!(s1.is_err());
         assert_eq!(s1.unwrap_err().variant.message(), ERROR);
+        // sample2 is still parsed to check it neither hangs nor panics, but the
+        // grammar now rejects it on an unescaped newline before it reaches the
+        // `escape ~ inner` recursion, so that recursion is covered explicitly.
         let s2 = json::JsonParser::parse(json::Rule::json, sample2);
         assert!(s2.is_err());
-        assert_eq!(s2.unwrap_err().variant.message(), ERROR);
+        let escapes = format!("\"{}\"", "\\\\".repeat(6000));
+        let s3 = json::JsonParser::parse(json::Rule::json, &escapes);
+        assert_eq!(s3.unwrap_err().variant.message(), ERROR);
     }
 
     #[test]

--- a/grammars/tests/json.rs
+++ b/grammars/tests/json.rs
@@ -100,6 +100,18 @@ fn string_with_escapes() {
 }
 
 #[test]
+fn string_rejects_unescaped_control_characters() {
+    // RFC 8259 section 7: U+0000 through U+001F must be escaped.
+    for input in ["\"\u{0}\"", "\"\t\"", "\"\u{1f}\""] {
+        assert!(
+            JsonParser::parse(Rule::json, input).is_err(),
+            "expected {:?} to be rejected",
+            input
+        );
+    }
+}
+
+#[test]
 fn array_empty() {
     parses_to! {
         parser: JsonParser,


### PR DESCRIPTION
## Problem

`pest_grammars`' JSON grammar accepts unescaped control characters inside strings:

```rust
JsonParser::parse(Rule::json, "\"a\tb\"").is_ok()  // true, should be false
```

[RFC 8259 §7](https://datatracker.ietf.org/doc/html/rfc8259#section-7) defines
`unescaped = %x20-21 / %x23-5B / %x5D-10FFFF` and states that the characters that
must be escaped are the quotation mark, the reverse solidus, "and the control
characters U+0000 through U+001F". The `inner` rule excluded only `"` and `\`, so
a literal tab, newline, or NUL inside a string was consumed as an ordinary
character.

I found this by fuzzing the grammar differentially against `serde_json`.

## Fix

One line: add the forbidden range to the negative set in `inner`.

U+007F and the C1 controls are deliberately left accepted — they fall inside
`%x5D-10FFFF` and the RFC restricts C0 only.

## The other two differences, and why they are not fixed here

The same fuzz run surfaced two more inputs where the grammar and `serde_json`
disagree. I do not believe either is a grammar bug:

- **Lone surrogates** (`"\uD800"`). §8.2 explicitly acknowledges that "the ABNF
  in this specification allows member names and string values to contain bit
  sequences that cannot encode Unicode characters; for example, `\uDEAD`". §7's
  escape production is `%x75 4HEXDIG` with no pairing constraint, so this is an
  interoperability caveat rather than a syntax rule.
- **Float overflow** (`1e1000`). §6's grammar has unbounded `DIGIT` and the RFC
  leaves range and precision to the implementation. `serde_json` rejects this
  when constructing the value, not when parsing.

## Effect on `json_handles_deep_nesting`

This is the one part of the diff worth a close look.

That test asserts both oss-fuzz corpus samples fail with `call limit reached`.
`jsonfuzzsample2.json` opens a string containing an unescaped newline, so under
the corrected grammar it is now rejected there instead of reaching the run of
10942 backslashes that used to drive `escape ~ inner` recursion.
`jsonfuzzsample1.json` contains no backslashes at all, so it only covers nesting
recursion — dropping sample2's assertion outright would have left the escape
chain with no coverage anywhere in the repo.

So the sample is still parsed, to confirm it neither hangs nor panics, and the
recursion it used to exercise now has an explicit synthetic case that trips the
same call limit. The synthetic case passes on the old grammar too, so it is a
standalone regression test rather than something coupled to this change.

Happy to drop the `sample2` parse entirely if you would rather not keep a
weakened assertion on it.

## Verification

- `cargo fmt --all -- --check`, and the full CI test command with all features, both clean.
- The new test fails on the unmodified grammar (`expected "\"\0\"" to be rejected`) and passes with it.
- I checked over-restriction by mutating the range in both directions; the
  existing `test_json_parse` and `test_line_col` catch over-restriction, and
  `examples.json` still parses unchanged.

## Follow-up, not in this diff

`toml.pest` has the same rule written as `!("\"" | "\\" | "\u{0000}" | "\u{001F}")`
— an alternation of the two endpoints rather than a range, so everything between
them still gets through. TOML's forbidden set differs from JSON's (it allows tab
and also excludes U+007F), so it deserves its own change; I can send one if useful.

---

Disclosure: I used an AI assistant while writing this. I ran the fuzzing, the
verification, and the mutation checks described above myself, and I understand
and take responsibility for the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON parsing now correctly rejects strings containing unescaped control characters.
  * Existing support for quoted strings, backslashes, and valid escape sequences is preserved.

* **Tests**
  * Added coverage for all control characters from U+0000 through U+001F.
  * Expanded deep-nesting validation, including handling of highly escaped JSON input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->