### PR TITLE
Make Display for Expr and OptimizedExpr re-parse to the same AST

### DIFF
--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -458,6 +458,48 @@ impl Iterator for ExprTopDownIterator {
     }
 }
 
+/// Grammars whose printed form has to parse back to what it was printed from.
+///
+/// Both layers round-trip the same corpus: [`Expr`] here, and
+/// [`crate::optimizer::OptimizedExpr`] in `optimizer::tests::display`. A new `Display` case
+/// belongs here rather than in a one-off test, so that both layers get it.
+#[cfg(test)]
+pub(crate) const ROUND_TRIP_GRAMMARS: &[&str] = &[
+    r#"r = { (!"a")? ~ "b" }"#,
+    r#"r = { (&"a"){2, 3} }"#,
+    r#"r = @{ (!"a"){2} }"#,
+    r#"r = { "\u{0001}" ~ ^"\u{000b}" ~ '\u{0007}'..'\u{000f}' }"#,
+    r#"r = { PUSH("a") ~ PEEK[0..-1] ~ POP }"#,
+    r#"r = { ("a" ~ "b") | ("a" ~ "c") }"#,
+    r#"r = ${ "a"* ~ "b"+ }"#,
+    r#"r = @{ "a"{2,} ~ "b"{,2} }"#,
+    r#"r = { SOI ~ ^"aB" ~ 'a'..'z' ~ EOI }"#,
+    r#"r = { PEEK_ALL ~ POP_ALL ~ DROP }"#,
+    r#"r = { ("a" | "b" | "c")+ }"#,
+    r#"r = { &"a" ~ "a" ~ r2 } r2 = _{ "b" }"#,
+    // The optimizer's restorer wraps the operand of `Opt`/`Rep` in `RestoreOnErr` when it
+    // touches the stack, so only the optimized layer sees these shapes.
+    r#"r = { (!PUSH("a"))? ~ "b" }"#,
+    r#"r = { (&PUSH("a"))? ~ "b" }"#,
+    r#"r = { (!("a" ~ POP))? ~ "b" }"#,
+    r#"r = { ((!PUSH("a"))? ~ ANY)* }"#,
+    r#"r = { (PUSH("a") | PUSH("b")) ~ "c" }"#,
+    r#"r = { ("a" ~ PUSH("b"))* }"#,
+];
+
+/// Reprints one rule as grammar source, keeping the modifier that its [`RuleType`] came from.
+#[cfg(test)]
+pub(crate) fn print_rule(name: &str, ty: RuleType, expr: impl core::fmt::Display) -> String {
+    let modifier = match ty {
+        RuleType::Normal => "",
+        RuleType::Silent => "_",
+        RuleType::Atomic => "@",
+        RuleType::CompoundAtomic => "$",
+        RuleType::NonAtomic => "!",
+    };
+    format!("{name} = {modifier}{{ {expr} }}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -577,26 +619,25 @@ mod tests {
             );
         }
 
-        /// Every rule of every grammar below is printed and parsed back; the AST has to survive.
+        /// Every rule of every [`ROUND_TRIP_GRAMMARS`] grammar is printed and parsed back;
+        /// the AST has to survive.
         #[test]
         fn display_round_trips_through_the_parser() {
             use crate::parser::{consume_rules, parse, Rule as PRule};
 
-            let sources = [
-                r#"r = { (!"a")? ~ "b" }"#,
-                r#"r = { (&"a"){2, 3} }"#,
-                r#"r = @{ (!"a"){2} }"#,
-                r#"r = { "\u{0001}" ~ ^"\u{000b}" ~ '\u{0007}'..'\u{000f}' }"#,
-                r#"r = { PUSH("a") ~ PEEK[0..-1] ~ POP }"#,
-                r#"r = { ("a" ~ "b") | ("a" ~ "c") }"#,
-            ];
-
-            for source in sources {
+            for source in ROUND_TRIP_GRAMMARS {
                 let rules = consume_rules(parse(PRule::grammar_rules, source).unwrap()).unwrap();
-                let printed = format!("r = {{ {} }}", rules[0].expr);
-                let reparsed = consume_rules(parse(PRule::grammar_rules, &printed).unwrap())
-                    .unwrap_or_else(|e| panic!("{printed} did not parse: {e:?}"));
-                assert_eq!(rules[0].expr, reparsed[0].expr, "printed as {printed}");
+                let printed = rules
+                    .iter()
+                    .map(|rule| print_rule(&rule.name, rule.ty, &rule.expr))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let reparsed = consume_rules(
+                    parse(PRule::grammar_rules, &printed)
+                        .unwrap_or_else(|e| panic!("{printed} did not parse: {e}")),
+                )
+                .unwrap_or_else(|e| panic!("{printed} was rejected: {e:?}"));
+                assert_eq!(rules, reparsed, "printed as {printed}");
             }
         }
 

--- a/meta/src/ast.rs
+++ b/meta/src/ast.rs
@@ -257,15 +257,64 @@ impl Expr {
     }
 }
 
+/// Writes `string` as a pest string or character literal delimited by `quote`.
+///
+/// `{:?}` cannot be used directly: for `U+0001..=U+000F` it emits the single-hex-digit form
+/// `\u{1}`, and pest's own `unicode` rule is `"u" ~ "{" ~ hex_digit{2, 6} ~ "}"`, so that form
+/// is not valid pest. Everything else is escaped exactly as `{:?}` escapes it, which is what
+/// keeps control characters out of generated doc comments.
+pub(crate) fn fmt_literal(
+    f: &mut core::fmt::Formatter<'_>,
+    string: &str,
+    quote: char,
+) -> core::fmt::Result {
+    write!(f, "{quote}")?;
+    for c in string.chars() {
+        match c {
+            _ if c == quote => write!(f, "\\{c}")?,
+            // The delimiter that is not in use needs no escape, just as `{:?}` leaves `'`
+            // alone inside a string and `"` alone inside a character.
+            '\'' | '"' => write!(f, "{c}")?,
+            '\u{1}'..='\u{8}' | '\u{b}' | '\u{c}' | '\u{e}' | '\u{f}' => {
+                write!(f, "\\u{{{:02x}}}", c as u32)?
+            }
+            _ => write!(f, "{}", c.escape_debug())?,
+        }
+    }
+    write!(f, "{quote}")
+}
+
+impl Expr {
+    /// Renders `self` as the operand of a postfix operator (`?`, `*`, `+`, `{n}`, ...).
+    ///
+    /// pest binds postfix operators tighter than the `&` and `!` prefixes, so a predicate
+    /// operand has to be parenthesised: without this, `Opt(NegPred(e))` would print as `!e?`,
+    /// which re-parses as `NegPred(Opt(e))` — a rule that always succeeds turned into one that
+    /// always fails.
+    fn as_postfix_operand(&self) -> String {
+        match self {
+            Expr::PosPred(_) | Expr::NegPred(_) => format!("({self})"),
+            _ => format!("{self}"),
+        }
+    }
+}
+
 impl core::fmt::Display for Expr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Expr::Str(s) => write!(f, "{s:?}"),
-            Expr::Insens(s) => write!(f, "^{s:?}"),
+            Expr::Str(s) => fmt_literal(f, s, '"'),
+            Expr::Insens(s) => {
+                write!(f, "^")?;
+                fmt_literal(f, s, '"')
+            }
             Expr::Range(start, end) => {
                 let start = start.chars().next().expect("Empty range start.");
                 let end = end.chars().next().expect("Empty range end.");
-                write!(f, "({start:?}..{end:?})")
+                write!(f, "(")?;
+                fmt_literal(f, start.encode_utf8(&mut [0; 4]), '\'')?;
+                write!(f, "..")?;
+                fmt_literal(f, end.encode_utf8(&mut [0; 4]), '\'')?;
+                write!(f, ")")
             }
             Expr::Ident(id) => write!(f, "{id}"),
             Expr::PeekSlice(start, end) => match end {
@@ -306,24 +355,32 @@ impl core::fmt::Display for Expr {
                     .join(" | ");
                 write!(f, "({sequence})")
             }
-            Expr::Opt(expr) => write!(f, "{expr}?"),
-            Expr::Rep(expr) => write!(f, "{expr}*"),
-            Expr::RepOnce(expr) => write!(f, "{expr}+"),
-            Expr::RepExact(expr, n) => write!(f, "{expr}{{{n}}}"),
-            Expr::RepMin(expr, min) => write!(f, "{expr}{{{min},}}"),
-            Expr::RepMax(expr, max) => write!(f, "{expr}{{,{max}}}"),
-            Expr::RepMinMax(expr, min, max) => write!(f, "{expr}{{{min}, {max}}}"),
+            Expr::Opt(expr) => write!(f, "{}?", expr.as_postfix_operand()),
+            Expr::Rep(expr) => write!(f, "{}*", expr.as_postfix_operand()),
+            Expr::RepOnce(expr) => write!(f, "{}+", expr.as_postfix_operand()),
+            Expr::RepExact(expr, n) => write!(f, "{}{{{n}}}", expr.as_postfix_operand()),
+            Expr::RepMin(expr, min) => write!(f, "{}{{{min},}}", expr.as_postfix_operand()),
+            Expr::RepMax(expr, max) => write!(f, "{}{{,{max}}}", expr.as_postfix_operand()),
+            Expr::RepMinMax(expr, min, max) => {
+                write!(f, "{}{{{min}, {max}}}", expr.as_postfix_operand())
+            }
             Expr::Skip(strings) => {
-                let strings = strings
-                    .iter()
-                    .map(|s| format!("{s:?}"))
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                write!(f, "(!({strings}) ~ ANY)*")
+                write!(f, "(!(")?;
+                for (i, s) in strings.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    fmt_literal(f, s, '"')?;
+                }
+                write!(f, ") ~ ANY)*")
             }
             Expr::Push(expr) => write!(f, "PUSH({expr})"),
             #[cfg(feature = "grammar-extras")]
-            Expr::PushLiteral(s) => write!(f, "PUSH_LITERAL({s:?})"),
+            Expr::PushLiteral(s) => {
+                write!(f, "PUSH_LITERAL(")?;
+                fmt_literal(f, s, '"')?;
+                write!(f, ")")
+            }
             #[cfg(feature = "grammar-extras")]
             Expr::NodeTag(expr, tag) => {
                 write!(f, "(#{tag} = {expr})")
@@ -474,6 +531,73 @@ mod tests {
         fn peek_slice() {
             assert_eq!(Expr::PeekSlice(0, None).to_string(), "PEEK[0..]");
             assert_eq!(Expr::PeekSlice(0, Some(-1)).to_string(), "PEEK[0..-1]");
+        }
+
+        #[test]
+        fn postfix_over_predicate_is_parenthesised() {
+            // pest binds postfix operators tighter than `&` and `!`, so an unparenthesised
+            // `!e?` would re-parse as `NegPred(Opt(e))` instead of `Opt(NegPred(e))`.
+            let neg = || Box::new(Expr::NegPred(Box::new(Expr::Ident("e".to_owned()))));
+            let pos = || Box::new(Expr::PosPred(Box::new(Expr::Ident("e".to_owned()))));
+
+            assert_eq!(Expr::Opt(neg()).to_string(), "(!e)?");
+            assert_eq!(Expr::Rep(neg()).to_string(), "(!e)*");
+            assert_eq!(Expr::RepOnce(neg()).to_string(), "(!e)+");
+            assert_eq!(Expr::RepExact(neg(), 2).to_string(), "(!e){2}");
+            assert_eq!(Expr::RepMin(neg(), 2).to_string(), "(!e){2,}");
+            assert_eq!(Expr::RepMax(neg(), 2).to_string(), "(!e){,2}");
+            assert_eq!(Expr::RepMinMax(pos(), 2, 3).to_string(), "(&e){2, 3}");
+
+            // Non-predicate operands keep their unparenthesised form.
+            assert_eq!(
+                Expr::Opt(Box::new(Expr::Ident("e".to_owned()))).to_string(),
+                "e?"
+            );
+        }
+
+        #[test]
+        fn control_characters_use_a_two_digit_unicode_escape() {
+            // pest's own rule is `unicode = @{ "u" ~ "{" ~ hex_digit{2, 6} ~ "}" }`, so the
+            // single-digit form `{:?}` emits for U+0001..=U+000F is not valid pest.
+            assert_eq!(Expr::Str("\u{1}".to_owned()).to_string(), r#""\u{01}""#);
+            assert_eq!(Expr::Insens("\u{f}".to_owned()).to_string(), r#"^"\u{0f}""#);
+            assert_eq!(
+                Expr::Range("\u{1}".to_owned(), "\u{b}".to_owned()).to_string(),
+                r#"('\u{01}'..'\u{0b}')"#,
+            );
+            // The escapes `{:?}` already gets right are unchanged.
+            assert_eq!(
+                Expr::Str("\0\t\n\r\\\"".to_owned()).to_string(),
+                r#""\0\t\n\r\\\"""#
+            );
+            assert_eq!(Expr::Str("a'b".to_owned()).to_string(), r#""a'b""#);
+            assert_eq!(
+                Expr::Range("'".to_owned(), "\"".to_owned()).to_string(),
+                r#"('\''..'"')"#,
+            );
+        }
+
+        /// Every rule of every grammar below is printed and parsed back; the AST has to survive.
+        #[test]
+        fn display_round_trips_through_the_parser() {
+            use crate::parser::{consume_rules, parse, Rule as PRule};
+
+            let sources = [
+                r#"r = { (!"a")? ~ "b" }"#,
+                r#"r = { (&"a"){2, 3} }"#,
+                r#"r = @{ (!"a"){2} }"#,
+                r#"r = { "\u{0001}" ~ ^"\u{000b}" ~ '\u{0007}'..'\u{000f}' }"#,
+                r#"r = { PUSH("a") ~ PEEK[0..-1] ~ POP }"#,
+                r#"r = { ("a" ~ "b") | ("a" ~ "c") }"#,
+            ];
+
+            for source in sources {
+                let rules = consume_rules(parse(PRule::grammar_rules, source).unwrap()).unwrap();
+                let printed = format!("r = {{ {} }}", rules[0].expr);
+                let reparsed = consume_rules(parse(PRule::grammar_rules, &printed).unwrap())
+                    .unwrap_or_else(|e| panic!("{printed} did not parse: {e:?}"));
+                assert_eq!(rules[0].expr, reparsed[0].expr, "printed as {printed}");
+            }
         }
 
         #[test]

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -273,9 +273,13 @@ impl OptimizedExpr {
     ///
     /// See [`crate::ast::Expr::as_postfix_operand`]: pest binds postfix operators tighter than
     /// the `&` and `!` prefixes, so a predicate operand has to be parenthesised.
+    ///
+    /// `RestoreOnErr` prints as its inner expression, and the restorer inserts exactly one of
+    /// them between `Opt`/`Rep` and their operand, so it has to be looked through here as well.
     fn as_postfix_operand(&self) -> String {
         match self {
             OptimizedExpr::PosPred(_) | OptimizedExpr::NegPred(_) => format!("({self})"),
+            OptimizedExpr::RestoreOnErr(expr) => expr.as_postfix_operand(),
             _ => format!("{self}"),
         }
     }
@@ -759,45 +763,6 @@ mod tests {
         /// and when the document comment breaks the line,
         /// it will be expanded into wrong codes.
         #[test]
-        fn postfix_over_predicate_is_parenthesised() {
-            let neg = || {
-                Box::new(OptimizedExpr::NegPred(Box::new(OptimizedExpr::Ident(
-                    "e".to_owned(),
-                ))))
-            };
-            let pos = || {
-                Box::new(OptimizedExpr::PosPred(Box::new(OptimizedExpr::Ident(
-                    "e".to_owned(),
-                ))))
-            };
-
-            assert_eq!(OptimizedExpr::Opt(neg()).to_string(), "(!e)?");
-            assert_eq!(OptimizedExpr::Rep(pos()).to_string(), "(&e)*");
-            assert_eq!(
-                OptimizedExpr::Opt(Box::new(OptimizedExpr::Ident("e".to_owned()))).to_string(),
-                "e?"
-            );
-        }
-
-        /// U+0001..=U+000F must not use the single-hex-digit form: pest's own rule is
-        /// `unicode = @{ "u" ~ "{" ~ hex_digit{2, 6} ~ "}" }`.
-        #[test]
-        fn control_character_below_u_0010() {
-            assert_eq!(
-                OptimizedExpr::Str("\u{1}".to_owned()).to_string(),
-                r#""\u{01}""#
-            );
-            assert_eq!(
-                OptimizedExpr::Range("\u{1}".to_owned(), "\u{f}".to_owned()).to_string(),
-                r#"('\u{01}'..'\u{0f}')"#,
-            );
-            assert_eq!(
-                OptimizedExpr::Skip(vec!["\u{b}".to_owned()]).to_string(),
-                r#"(!("\u{0b}") ~ ANY)*"#,
-            );
-        }
-
-        #[test]
         fn control_character() {
             assert_eq!(OptimizedExpr::Str("\n".to_owned()).to_string(), "\"\\n\"");
             assert_eq!(
@@ -820,6 +785,143 @@ mod tests {
             );
 
             assert_ne!(OptimizedExpr::Str("\n".to_owned()).to_string(), "\"\n\"");
+        }
+
+        /// U+0001..=U+000F must not use the single-hex-digit form: pest's own rule is
+        /// `unicode = @{ "u" ~ "{" ~ hex_digit{2, 6} ~ "}" }`.
+        #[test]
+        fn control_character_below_u_0010() {
+            assert_eq!(
+                OptimizedExpr::Str("\u{1}".to_owned()).to_string(),
+                r#""\u{01}""#
+            );
+            assert_eq!(
+                OptimizedExpr::Range("\u{1}".to_owned(), "\u{f}".to_owned()).to_string(),
+                r#"('\u{01}'..'\u{0f}')"#,
+            );
+            assert_eq!(
+                OptimizedExpr::Skip(vec!["\u{b}".to_owned()]).to_string(),
+                r#"(!("\u{0b}") ~ ANY)*"#,
+            );
+        }
+
+        #[test]
+        fn postfix_over_predicate_is_parenthesised() {
+            let neg = || {
+                Box::new(OptimizedExpr::NegPred(Box::new(OptimizedExpr::Ident(
+                    "e".to_owned(),
+                ))))
+            };
+            let pos = || {
+                Box::new(OptimizedExpr::PosPred(Box::new(OptimizedExpr::Ident(
+                    "e".to_owned(),
+                ))))
+            };
+
+            assert_eq!(OptimizedExpr::Opt(neg()).to_string(), "(!e)?");
+            assert_eq!(OptimizedExpr::Rep(pos()).to_string(), "(&e)*");
+            assert_eq!(
+                OptimizedExpr::Opt(Box::new(OptimizedExpr::Ident("e".to_owned()))).to_string(),
+                "e?"
+            );
+        }
+
+        /// `RestoreOnErr` prints as its inner expression, so a predicate under one still
+        /// needs the parentheses. This is the shape the restorer produces for
+        /// `(!PUSH("a"))?`: without looking through the wrapper, `Opt` printed `!PUSH("a")?`,
+        /// which parses back as `NegPred(Opt(...))`.
+        #[test]
+        fn postfix_over_restored_predicate_is_parenthesised() {
+            let restored = |expr| Box::new(OptimizedExpr::RestoreOnErr(Box::new(expr)));
+            let e = || Box::new(OptimizedExpr::Ident("e".to_owned()));
+
+            assert_eq!(
+                OptimizedExpr::Opt(restored(OptimizedExpr::NegPred(e()))).to_string(),
+                "(!e)?"
+            );
+            assert_eq!(
+                OptimizedExpr::Rep(restored(OptimizedExpr::PosPred(e()))).to_string(),
+                "(&e)*"
+            );
+            // A restored non-predicate operand is still printed bare.
+            assert_eq!(
+                OptimizedExpr::Opt(restored(OptimizedExpr::Ident("e".to_owned()))).to_string(),
+                "e?"
+            );
+        }
+
+        /// Right-associates `Seq` and `Choice`, the way [`super::super::rotator`] does.
+        ///
+        /// `Display` flattens a `Seq`/`Choice` chain to `(a ~ b ~ c)`, so the nesting is not
+        /// recoverable from the printed form — and does not need to be, both operators are
+        /// associative. The rotator normalises the nesting but runs before the unroller,
+        /// which can put a left-nested `Seq` back (`"a"{2,} ~ "b"{,2}`), so the two sides of
+        /// the round trip below can differ in nesting alone.
+        fn right_associate(expr: OptimizedExpr) -> OptimizedExpr {
+            fn rotate(expr: OptimizedExpr) -> OptimizedExpr {
+                match expr {
+                    OptimizedExpr::Seq(lhs, rhs) => match *lhs {
+                        OptimizedExpr::Seq(ll, lr) => rotate(OptimizedExpr::Seq(
+                            ll,
+                            Box::new(OptimizedExpr::Seq(lr, rhs)),
+                        )),
+                        lhs => OptimizedExpr::Seq(Box::new(lhs), rhs),
+                    },
+                    OptimizedExpr::Choice(lhs, rhs) => match *lhs {
+                        OptimizedExpr::Choice(ll, lr) => rotate(OptimizedExpr::Choice(
+                            ll,
+                            Box::new(OptimizedExpr::Choice(lr, rhs)),
+                        )),
+                        lhs => OptimizedExpr::Choice(Box::new(lhs), rhs),
+                    },
+                    expr => expr,
+                }
+            }
+
+            expr.map_top_down(rotate)
+        }
+
+        /// The round trip of [`crate::ast::ROUND_TRIP_GRAMMARS`], one layer down: an
+        /// optimized grammar is printed, parsed back and optimized again, and has to come
+        /// out unchanged. `RestoreOnErr` only exists at this layer, so only this test sees
+        /// the shapes the restorer builds.
+        #[test]
+        fn display_round_trips_through_the_parser() {
+            use crate::ast::{print_rule, ROUND_TRIP_GRAMMARS};
+            use crate::parser::{consume_rules, parse, Rule as PRule};
+
+            for source in ROUND_TRIP_GRAMMARS {
+                let optimized =
+                    optimize(consume_rules(parse(PRule::grammar_rules, source).unwrap()).unwrap());
+                let printed = optimized
+                    .iter()
+                    .map(|rule| print_rule(&rule.name, rule.ty, &rule.expr))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let reoptimized = optimize(
+                    consume_rules(
+                        parse(PRule::grammar_rules, &printed)
+                            .unwrap_or_else(|e| panic!("{printed} did not parse: {e}")),
+                    )
+                    .unwrap_or_else(|e| panic!("{printed} was rejected: {e:?}")),
+                );
+
+                let normalize = |rules: Vec<OptimizedRule>| {
+                    rules
+                        .into_iter()
+                        .map(|rule| OptimizedRule {
+                            name: rule.name,
+                            ty: rule.ty,
+                            expr: right_associate(rule.expr),
+                        })
+                        .collect::<Vec<_>>()
+                };
+                assert_eq!(
+                    normalize(optimized),
+                    normalize(reoptimized),
+                    "printed as {printed}"
+                );
+            }
         }
 
         #[test]

--- a/meta/src/optimizer/mod.rs
+++ b/meta/src/optimizer/mod.rs
@@ -268,15 +268,35 @@ impl OptimizedExpr {
     }
 }
 
+impl OptimizedExpr {
+    /// Renders `self` as the operand of a postfix operator (`?`, `*`, `+`).
+    ///
+    /// See [`crate::ast::Expr::as_postfix_operand`]: pest binds postfix operators tighter than
+    /// the `&` and `!` prefixes, so a predicate operand has to be parenthesised.
+    fn as_postfix_operand(&self) -> String {
+        match self {
+            OptimizedExpr::PosPred(_) | OptimizedExpr::NegPred(_) => format!("({self})"),
+            _ => format!("{self}"),
+        }
+    }
+}
+
 impl core::fmt::Display for OptimizedExpr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            OptimizedExpr::Str(s) => write!(f, "{s:?}"),
-            OptimizedExpr::Insens(s) => write!(f, "^{s:?}"),
+            OptimizedExpr::Str(s) => fmt_literal(f, s, '"'),
+            OptimizedExpr::Insens(s) => {
+                write!(f, "^")?;
+                fmt_literal(f, s, '"')
+            }
             OptimizedExpr::Range(start, end) => {
                 let start = start.chars().next().expect("Empty range start.");
                 let end = end.chars().next().expect("Empty range end.");
-                write!(f, "({start:?}..{end:?})")
+                write!(f, "(")?;
+                fmt_literal(f, start.encode_utf8(&mut [0; 4]), '\'')?;
+                write!(f, "..")?;
+                fmt_literal(f, end.encode_utf8(&mut [0; 4]), '\'')?;
+                write!(f, ")")
             }
             OptimizedExpr::Ident(id) => write!(f, "{id}"),
             OptimizedExpr::PeekSlice(start, end) => match end {
@@ -317,21 +337,27 @@ impl core::fmt::Display for OptimizedExpr {
                     .join(" | ");
                 write!(f, "({sequence})")
             }
-            OptimizedExpr::Opt(expr) => write!(f, "{expr}?"),
-            OptimizedExpr::Rep(expr) => write!(f, "{expr}*"),
+            OptimizedExpr::Opt(expr) => write!(f, "{}?", expr.as_postfix_operand()),
+            OptimizedExpr::Rep(expr) => write!(f, "{}*", expr.as_postfix_operand()),
             #[cfg(feature = "grammar-extras")]
-            OptimizedExpr::RepOnce(expr) => write!(f, "{expr}+"),
+            OptimizedExpr::RepOnce(expr) => write!(f, "{}+", expr.as_postfix_operand()),
             OptimizedExpr::Skip(strings) => {
-                let strings = strings
-                    .iter()
-                    .map(|s| format!("{s:?}"))
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                write!(f, "(!({strings}) ~ ANY)*")
+                write!(f, "(!(")?;
+                for (i, s) in strings.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    fmt_literal(f, s, '"')?;
+                }
+                write!(f, ") ~ ANY)*")
             }
             OptimizedExpr::Push(expr) => write!(f, "PUSH({expr})"),
             #[cfg(feature = "grammar-extras")]
-            OptimizedExpr::PushLiteral(s) => write!(f, "PUSH_LITERAL({s:?})"),
+            OptimizedExpr::PushLiteral(s) => {
+                write!(f, "PUSH_LITERAL(")?;
+                fmt_literal(f, s, '"')?;
+                write!(f, ")")
+            }
             #[cfg(feature = "grammar-extras")]
             OptimizedExpr::NodeTag(expr, tag) => {
                 write!(f, "(#{tag} = {expr})")
@@ -732,6 +758,45 @@ mod tests {
         /// for it expand `#[doc("...")]` to `/// ...`,
         /// and when the document comment breaks the line,
         /// it will be expanded into wrong codes.
+        #[test]
+        fn postfix_over_predicate_is_parenthesised() {
+            let neg = || {
+                Box::new(OptimizedExpr::NegPred(Box::new(OptimizedExpr::Ident(
+                    "e".to_owned(),
+                ))))
+            };
+            let pos = || {
+                Box::new(OptimizedExpr::PosPred(Box::new(OptimizedExpr::Ident(
+                    "e".to_owned(),
+                ))))
+            };
+
+            assert_eq!(OptimizedExpr::Opt(neg()).to_string(), "(!e)?");
+            assert_eq!(OptimizedExpr::Rep(pos()).to_string(), "(&e)*");
+            assert_eq!(
+                OptimizedExpr::Opt(Box::new(OptimizedExpr::Ident("e".to_owned()))).to_string(),
+                "e?"
+            );
+        }
+
+        /// U+0001..=U+000F must not use the single-hex-digit form: pest's own rule is
+        /// `unicode = @{ "u" ~ "{" ~ hex_digit{2, 6} ~ "}" }`.
+        #[test]
+        fn control_character_below_u_0010() {
+            assert_eq!(
+                OptimizedExpr::Str("\u{1}".to_owned()).to_string(),
+                r#""\u{01}""#
+            );
+            assert_eq!(
+                OptimizedExpr::Range("\u{1}".to_owned(), "\u{f}".to_owned()).to_string(),
+                r#"('\u{01}'..'\u{0f}')"#,
+            );
+            assert_eq!(
+                OptimizedExpr::Skip(vec!["\u{b}".to_owned()]).to_string(),
+                r#"(!("\u{0b}") ~ ANY)*"#,
+            );
+        }
+
         #[test]
         fn control_character() {
             assert_eq!(OptimizedExpr::Str("\n".to_owned()).to_string(), "\"\\n\"");


### PR DESCRIPTION
`Display for Expr`/`OptimizedExpr` prints pest source that does not always re-parse to the expression it came from.

**1. Postfix binds tighter than `&`/`!`.** `Opt(NegPred(e))` prints `!e?`, re-parsed as `NegPred(Opt(e))`:

```
r = { (!"a")? ~ "b" }           parses "b"
printed: r = { (!"a"? ~ "b") }  parses nothing (`!(a?)` can never succeed)
```

Of 224 prefix×postfix×atom grammars (5×8×8) pest accepts, **128 print to a different AST**. After: 0.

**2. `{:?}` emits `\u{1}` for U+0001..=U+000F**, but pest's own rule is `unicode = @{ "u" ~ "{" ~ hex_digit{2, 6} ~ "}" }`, so that output is not valid pest:

```
r = { "\u{0001}" }  ->  r = { "\u{1}" }  ->  parse error: expected quote
```

Over `Str`/`Insens`/`Range` for U+0000..U+3000, **36 of 36,867 literals fail to re-parse**. After: 0.

`fmt_literal` keeps every escape `{:?}` already got right (that is what keeps control characters out of doc comments, #895) and pads those twelve.

Reverting the impl fails all 5 new tests, no existing one. Two naive alternatives rejected: parenthesising *every* postfix operand round-trips but breaks 7 existing Display tests; relaxing the grammar to `hex_digit{1, 6}` instead **panics** at `parser.rs:447`, where `unescape` enforces the minimum too.

Not addressed: `a ~ b ~ c` round-trips to a left-associated `Seq` (3 of 414 rules here); semantically identical, and the rotator normalises it.

Local: 641 tests pass (636 on master); fmt, clippy `-Dwarnings`, check, doc, bootstrap clean. CI has not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected expression formatting so postfix operators preserve predicate grouping when displayed.
  * Improved escaping for low-valued control characters, ensuring displayed expressions can be parsed reliably again.
  * Updated optimized expression output to apply the same literal escaping and predicate parenthesization rules, including restored predicates.

* **Tests**
  * Added coverage for formatted expression round-trips, optimized grammars, predicate postfix operators, and control-character escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->