### PR TITLE
bump version to 2.9.1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the most recent minor version is supported.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.7.x   | :white_check_mark: |
-| < 2.7.x | :x:                |
+| 2.9.x   | :white_check_mark: |
+| < 2.9.x | :x:                |
 
 
 ## Reporting a Vulnerability

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_debugger"
 description = "pest grammar debugger"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = [
     "Dragoș Tiselice <dragostiselice@gmail.com>",
@@ -17,9 +17,9 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.9.0" }
-pest_meta = { path = "../meta", version = "2.9.0" }
-pest_vm = { path = "../vm", version = "2.9.0" }
+pest = { path = "../pest", version = "2.9.1" }
+pest_meta = { path = "../meta", version = "2.9.1" }
+pest_vm = { path = "../vm", version = "2.9.1" }
 reqwest = { version = "= 0.11.13", default-features = false, features = [
     "blocking",
     "json",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_derive"
 description = "pest's derive macro"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -24,5 +24,5 @@ grammar-extras = ["pest_generator/grammar-extras"]
 
 [dependencies]
 # for tests, included transitively anyway
-pest = { path = "../pest", version = "2.9.0", default-features = false }
-pest_generator = { path = "../generator", version = "2.9.0", default-features = false }
+pest = { path = "../pest", version = "2.9.1", default-features = false }
+pest_generator = { path = "../generator", version = "2.9.1", default-features = false }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_generator"
 description = "pest code generator"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -21,8 +21,8 @@ grammar-extras = ["pest_meta/grammar-extras"]
 export-internal = []
 
 [dependencies]
-pest = { path = "../pest", version = "2.9.0", default-features = false }
-pest_meta = { path = "../meta", version = "2.9.0" }
+pest = { path = "../pest", version = "2.9.1", default-features = false }
+pest_meta = { path = "../meta", version = "2.9.1" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/grammars/Cargo.toml
+++ b/grammars/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_grammars"
 description = "pest popular grammar implementations"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.9.0" }
-pest_derive = { path = "../derive", version = "2.9.0" }
+pest = { path = "../pest", version = "2.9.1" }
+pest_derive = { path = "../derive", version = "2.9.1" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_meta"
 description = "pest meta language parser and validator"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -21,7 +21,7 @@ include = [
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.9.0" }
+pest = { path = "../pest", version = "2.9.1" }
 
 [features]
 default = []

--- a/pest/Cargo.toml
+++ b/pest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest"
 description = "The Elegant Parser"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pest_vm"
 description = "pest grammar virtual machine"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Dragoș Tiselice <dragostiselice@gmail.com>"]
 homepage = "https://pest.rs/"
@@ -14,8 +14,8 @@ readme = "_README.md"
 rust-version = "1.83"
 
 [dependencies]
-pest = { path = "../pest", version = "2.9.0" }
-pest_meta = { path = "../meta", version = "2.9.0" }
+pest = { path = "../pest", version = "2.9.1" }
+pest_meta = { path = "../meta", version = "2.9.1" }
 
 [features]
 grammar-extras = ["pest_meta/grammar-extras"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the Pest suite and related crates to version 2.9.1.
  - Updated supported-version guidance to identify 2.9.x as supported and earlier versions as unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->