### PR TITLE
Stop Span::lines from yielding a line past the span

### DIFF
--- a/pest/src/error.rs
+++ b/pest/src/error.rs
@@ -1048,6 +1048,35 @@ mod tests {
     }
 
     #[test]
+    fn display_custom_span_end_after_inner_newline() {
+        let input = "abcdef\nghi";
+        let start = Position::new(input, 0).unwrap();
+        let end = Position::new(input, 7).unwrap();
+        assert!(start.at_start());
+        assert!(!end.at_end());
+
+        let error: Error<u32> = Error::new_from_span(
+            ErrorVariant::CustomError {
+                message: "error: big one".to_owned(),
+            },
+            start.span(&end),
+        );
+
+        assert_eq!(
+            format!("{error}"),
+            [
+                " --> 1:1",
+                "  |",
+                "1 | abcdef␊",
+                "  | ^-----^",
+                "  |",
+                "  = error: big one"
+            ]
+            .join("\n")
+        );
+    }
+
+    #[test]
     fn display_custom_span_empty() {
         let input = "";
         let start = Position::new(input, 0).unwrap();

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -364,7 +364,11 @@ pub struct LinesSpan<'i> {
 impl<'i> Iterator for LinesSpan<'i> {
     type Item = Span<'i>;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos > self.span.end {
+        // `pos` holds the start of the next line to yield, so every line the span
+        // covers has been yielded once `pos` has reached the end of the span. The
+        // exception is a zero-width span, which still sits on one line: that line is
+        // yielded by the first call, while `pos` is still the start of the span.
+        if self.pos >= self.span.end && self.pos > self.span.start {
             return None;
         }
         let pos = position::Position::new(self.span.input, self.pos)?;
@@ -490,6 +494,34 @@ mod tests {
         assert_eq!(lines[0], "def\n".to_owned());
         assert_eq!(lines[1], "ghi".to_owned());
         assert_eq!(lines, lines_span) // Verify parity with lines_span()
+    }
+
+    #[test]
+    fn lines_ending_on_line_break() {
+        let input = "abc\ndef\nghi";
+        let span = Span::new(input, 1, 4).unwrap();
+        assert_eq!(span.as_str(), "bc\n");
+        let lines: Vec<_> = span.lines().collect();
+        let lines_span: Vec<_> = span.lines_span().collect();
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "abc\n".to_owned());
+        assert_eq!(lines_span.len(), 1);
+        assert_eq!(lines_span[0], Span::new(input, 0, 4).unwrap());
+    }
+
+    #[test]
+    fn lines_of_empty_span() {
+        let input = "abc\ndef\nghi";
+        let span = Span::new(input, 5, 5).unwrap();
+        assert_eq!(span.as_str(), "");
+        let lines: Vec<_> = span.lines().collect();
+        let lines_span: Vec<_> = span.lines_span().collect();
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "def\n".to_owned());
+        assert_eq!(lines_span.len(), 1);
+        assert_eq!(lines_span[0], Span::new(input, 4, 8).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
`Span::lines()` and `Span::lines_span()` yield one line too many whenever the span ends on a line break. `LinesSpan::next` (pest/src/span.rs, line 367 on master) stops only once its cursor is strictly past `span.end`, but the cursor is exactly `span.end` after it yields the line that ends there, so the iterator carries on and yields the whole following line, which the span does not cover.

`Error::new_from_span` consumes that iterator and keeps its last item as `continued_line`, so the extra line shows up in rendered errors. For input `"abcdef\nghi"` and a span over `"abcdef\n"`, master prints:

```
 --> 1:1
  |
1 | abcdef␊
1 | ghi
  | ^-----^
  |
  = error: big one
```

Line number 1 is printed twice and the second line of text is not part of the span. When the line that leaks in ends in a line break of its own, that break is emitted raw and splits the block with a blank line, because `continued_line` skips the whitespace visualization that the first line gets. With this change the same error prints:

```
 --> 1:1
  |
1 | abcdef␊
  | ^-----^
  |
  = error: big one
```

The fix is to stop the cursor when it reaches `span.end` instead of when it passes it. A zero-width span still sits on one line, so the guard keeps yielding on the first call, when the cursor is still `span.start`; `lines_of_empty_span` pins that behaviour down and passes both with and without the fix.

Verification on 66513d2 with Rust 1.95, macOS aarch64:

```
cargo fmt --all -- --check                                                     # clean
cargo clippy -p pest --features pretty-print,const_prec_climber,memchr,miette-error --all-targets -- -Dwarnings   # clean
cargo test -p pest --features pretty-print,const_prec_climber,memchr,miette-error   # 101 lib, 7 calculator, 11 json, 83 doctests, all pass
cargo test -p pest_meta --features grammar-extras                              # 183 pass
cargo test -p pest_derive --features grammar-extras                            # 101 pass, 12 ignored
```

With the one-line guard reverted and the tests kept, `span::tests::lines_ending_on_line_break` fails with 2 lines where 1 is expected and `error::tests::display_custom_span_end_after_inner_newline` fails with the duplicated line number shown above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected multi-line error rendering when an error span ends immediately after a line break.
  - Improved line-range handling for spans that end on a line break.
  - Preserved correct behavior for zero-width spans, ensuring their associated line remains available for display.

- **Tests**
  - Added coverage for custom error formatting, line-ending spans, and empty spans to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->